### PR TITLE
Update NFCLI data for the game's December minor update

### DIFF
--- a/data/components.json
+++ b/data/components.json
@@ -1,0 +1,1192 @@
+{
+  "Components": [
+    {
+      "Key": "Stock/Basic CIC",
+      "Name": "Basic CIC",
+      "MaxHP": "200",
+      "MinHP": "10",
+      "Crew": "20",
+      "Restores": "0",
+      "Priority": "High"
+    },
+    {
+      "Key": "Stock/Reinforced CIC",
+      "Name": "Reinforced CIC",
+      "MaxHP": "200",
+      "MinHP": "10",
+      "Crew": "20",
+      "Restores": "0",
+      "Priority": "High"
+    },
+    {
+      "Key": "Stock/Citadel CIC",
+      "Name": "Citadel CIC",
+      "MaxHP": "400",
+      "MinHP": "20",
+      "Crew": "40",
+      "Restores": "0",
+      "Priority": "High"
+    },
+    {
+      "Key": "Stock/Auxiliary Steering",
+      "Name": "Auxiliary Steering",
+      "MaxHP": "300",
+      "MinHP": "10",
+      "Crew": "5",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Berthing",
+      "Name": "Berthing",
+      "MaxHP": "50",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Small DC Locker",
+      "Name": "Small DC Locker",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "10",
+      "Restores": "1",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Reinforced DC Locker",
+      "Name": "Reinforced DC Locker",
+      "MaxHP": "200",
+      "MinHP": "20",
+      "Crew": "10",
+      "Restores": "1",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Large DC Locker",
+      "Name": "Large DC Locker",
+      "MaxHP": "150",
+      "MinHP": "10",
+      "Crew": "15",
+      "Restores": "2",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Rapid DC Locker",
+      "Name": "Rapid DC Locker",
+      "MaxHP": "70",
+      "MinHP": "10",
+      "Crew": "5",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Damage Control Central",
+      "Name": "Damage Control Central",
+      "MaxHP": "200",
+      "MinHP": "15",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Small Workshop",
+      "Name": "Small Workshop",
+      "MaxHP": "150",
+      "MinHP": "15",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Bulk Magazine",
+      "Name": "Bulk Magazine",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Reinforced Magazine",
+      "Name": "Reinforced Magazine",
+      "MaxHP": "150",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Gun Plotting Center",
+      "Name": "Gun Plotting Center",
+      "MaxHP": "100",
+      "MinHP": "15",
+      "Crew": "30",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Battle Dressing Station",
+      "Name": "Battle Dressing Station",
+      "MaxHP": "125",
+      "MinHP": "15",
+      "Crew": "8",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Analysis Annex",
+      "Name": "Analysis Annex",
+      "MaxHP": "100",
+      "MinHP": "15",
+      "Crew": "20",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Intelligence Center",
+      "Name": "Intelligence Center",
+      "MaxHP": "200",
+      "MinHP": "15",
+      "Crew": "45",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Plant Control Center",
+      "Name": "Plant Control Center",
+      "MaxHP": "100",
+      "MinHP": "15",
+      "Crew": "15",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Small Reactor Booster",
+      "Name": "Small Reactor Booster",
+      "MaxHP": "40",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Adaptive Radar Receiver",
+      "Name": "Adaptive Radar Receiver",
+      "MaxHP": "40",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Track Correlator",
+      "Name": "Track Correlator",
+      "MaxHP": "40",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Strobe Correlator",
+      "Name": "Strobe Correlator",
+      "MaxHP": "40",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Mount Gyros",
+      "Name": "Mount Gyros",
+      "MaxHP": "40",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Supplementary Radio Amplifiers",
+      "Name": "Supplementary Radio Amplifiers",
+      "MaxHP": "40",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Launcher Deluge System",
+      "Name": "Launcher Deluge System",
+      "MaxHP": "75",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Magazine Sprinklers",
+      "Name": "Magazine Sprinklers",
+      "MaxHP": "75",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Redundant Reactor Failsafes",
+      "Name": "Redundant Reactor Failsafes",
+      "MaxHP": "75",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Reinforced Thruster Nozzles",
+      "Name": "Reinforced Thruster Nozzles",
+      "MaxHP": "50",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Energy Regulator",
+      "Name": "Energy Regulator",
+      "MaxHP": "100",
+      "MinHP": "15",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Small Energy Regulator",
+      "Name": "Small Energy Regulator",
+      "MaxHP": "75",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Focused Particle Accelerator",
+      "Name": "Focused Particle Accelerator",
+      "MaxHP": "150",
+      "MinHP": "15",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Ammunition Elevators",
+      "Name": "Ammunition Elevators",
+      "MaxHP": "100",
+      "MinHP": "15",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Rapid-Cycle Cradle",
+      "Name": "Rapid-Cycle Cradle",
+      "MaxHP": "100",
+      "MinHP": "15",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Actively Cooled Amplifiers",
+      "Name": "Actively Cooled Amplifiers",
+      "MaxHP": "40",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Missile Programming Bus",
+      "Name": "Missile Programming Bus",
+      "MaxHP": "80",
+      "MinHP": "15",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Missile Programming Bus Array",
+      "Name": "Missile Programming Bus Array",
+      "MaxHP": "100",
+      "MinHP": "15",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Missile Parallel Interface",
+      "Name": "Missile Parallel Interface",
+      "MaxHP": "100",
+      "MinHP": "15",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/CR10 Antenna",
+      "Name": "CR10 Antenna",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/VLS-1-23 Launcher",
+      "Name": "VLS-1-23 Launcher",
+      "MaxHP": "75",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/VLS-1-46 Launcher",
+      "Name": "VLS-1-46 Launcher",
+      "MaxHP": "125",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Strike Planning Center",
+      "Name": "Strike Planning Center",
+      "MaxHP": "100",
+      "MinHP": "15",
+      "Crew": "20",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/FM200 Drive",
+      "Name": "FM200 Drive",
+      "MaxHP": "250",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/FM200R Drive",
+      "Name": "FM200R Drive",
+      "MaxHP": "500",
+      "MinHP": "25",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/FM230 'Whiplash' Drive",
+      "Name": "FM230 'Whiplash' Drive",
+      "MaxHP": "250",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/FM240 'Dragonfly' Drive",
+      "Name": "FM240 'Dragonfly' Drive",
+      "MaxHP": "250",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/FM280 'Raider' Drive",
+      "Name": "FM280 'Raider' Drive",
+      "MaxHP": "250",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/FM30X 'Prowler' Drive",
+      "Name": "FM30X 'Prowler' Drive",
+      "MaxHP": "200",
+      "MinHP": "30",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/FM500 Drive",
+      "Name": "FM500 Drive",
+      "MaxHP": "1000",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/FM500R Drive",
+      "Name": "FM500R Drive",
+      "MaxHP": "1500",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/FM530 'Whiplash' Drive",
+      "Name": "FM530 'Whiplash' Drive",
+      "MaxHP": "1000",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/FM540 'Dragonfly' Drive",
+      "Name": "FM540 'Dragonfly' Drive",
+      "MaxHP": "1000",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/FM580 'Raider' Drive",
+      "Name": "FM580 'Raider' Drive",
+      "MaxHP": "1000",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/FR3300 Micro Reactor",
+      "Name": "FR3300 Micro Reactor",
+      "MaxHP": "200",
+      "MinHP": "50",
+      "Crew": "5",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/FR4800 Reactor",
+      "Name": "FR4800 Reactor",
+      "MaxHP": "300",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/RS35 'Frontline' Radar",
+      "Name": "RS35 'Frontline' Radar",
+      "MaxHP": "200",
+      "MinHP": "30",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "High"
+    },
+    {
+      "Key": "Stock/RS41 'Spyglass' Radar",
+      "Name": "RS41 'Spyglass' Radar",
+      "MaxHP": "200",
+      "MinHP": "30",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "High"
+    },
+    {
+      "Key": "Stock/RM50 'Parallax' Radar",
+      "Name": "RM50 'Parallax' Radar",
+      "MaxHP": "300",
+      "MinHP": "30",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "High"
+    },
+    {
+      "Key": "Stock/Mk61 Cannon",
+      "Name": "Mk61 Cannon",
+      "MaxHP": "150",
+      "MinHP": "10",
+      "Crew": "4",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk62 Cannon",
+      "Name": "Mk62 Cannon",
+      "MaxHP": "150",
+      "MinHP": "10",
+      "Crew": "8",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk64 Cannon",
+      "Name": "Mk64 Cannon",
+      "MaxHP": "225",
+      "MinHP": "15",
+      "Crew": "15",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk65 Cannon",
+      "Name": "Mk65 Cannon",
+      "MaxHP": "450",
+      "MinHP": "30",
+      "Crew": "25",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk66 Cannon",
+      "Name": "Mk66 Cannon",
+      "MaxHP": "550",
+      "MinHP": "30",
+      "Crew": "25",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk68 Cannon",
+      "Name": "Mk68 Cannon",
+      "MaxHP": "650",
+      "MinHP": "30",
+      "Crew": "40",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk81 Railgun",
+      "Name": "Mk81 Railgun",
+      "MaxHP": "300",
+      "MinHP": "30",
+      "Crew": "15",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk550 Mass Driver",
+      "Name": "Mk550 Railgun",
+      "MaxHP": "450",
+      "MinHP": "20",
+      "Crew": "15",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk600 Beam Cannon",
+      "Name": "Mk600 Beam Cannon",
+      "MaxHP": "450",
+      "MinHP": "20",
+      "Crew": "15",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk610 Beam Turret",
+      "Name": "Mk610 Beam Turret",
+      "MaxHP": "400",
+      "MinHP": "30",
+      "Crew": "20",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/VLS-2 Launcher",
+      "Name": "VLS-2 Launcher",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "High"
+    },
+    {
+      "Key": "Stock/VLS-3 Launcher",
+      "Name": "VLS-3 Launcher",
+      "MaxHP": "175",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "High"
+    },
+    {
+      "Key": "Stock/CLS-3 Launcher",
+      "Name": "CLS-3 Launcher",
+      "MaxHP": "175",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "High"
+    },
+    {
+      "Key": "Stock/Torpedo Turret",
+      "Name": "TLS-3 Launcher",
+      "MaxHP": "350",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk20 'Defender' PDT",
+      "Name": "Mk20 'Defender' PDT",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "3",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk25 'Rebound' PDT",
+      "Name": "Mk25 'Rebound' PDT",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "3",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk29 'Stonewall' PDT",
+      "Name": "Mk29 'Stonewall' PDT",
+      "MaxHP": "150",
+      "MinHP": "10",
+      "Crew": "5",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk90 'Aurora' PDT",
+      "Name": "Mk90 'Aurora' PDT",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Mk95 'Sarissa' PDT",
+      "Name": "Mk95 'Sarissa' PDT",
+      "MaxHP": "150",
+      "MinHP": "10",
+      "Crew": "4",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/ES22 'Pinard' Electronic Support Module",
+      "Name": "ES22 'Pinard' Electronic Support Module",
+      "MaxHP": "50",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/ES32 'Scryer' Missile ID System",
+      "Name": "ES32 'Scryer' Missile ID System",
+      "MaxHP": "150",
+      "MinHP": "15",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/E55 'Spotlight' Illuminator",
+      "Name": "E55 'Spotlight' Illuminator",
+      "MaxHP": "75",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/E57 'Floodlight' Illuminator",
+      "Name": "E57 'Floodlight' Illuminator",
+      "MaxHP": "75",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/E71 'Hangup' Jammer",
+      "Name": "E71 'Hangup' Jammer",
+      "MaxHP": "75",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/E70 'Interruption' Jammer",
+      "Name": "E70 'Interruption' Jammer",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/E90 'Blanket' Jammer",
+      "Name": "E90 'Blanket' Jammer",
+      "MaxHP": "75",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/RF101 'Bullseye' Radar",
+      "Name": "RF101 'Bullseye' Radar",
+      "MaxHP": "70",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/E15 'Masquerade' Signature Booster",
+      "Name": "E15 'Masquerade' Deception Module",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Signature Scrambler",
+      "Name": "Signature Scrambler",
+      "MaxHP": "50",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/CR70 Antenna",
+      "Name": "CR70 Antenna",
+      "MaxHP": "250",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Civilian Reactor",
+      "Name": "Civilian Reactor",
+      "MaxHP": "300",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/Light Civilian Reactor",
+      "Name": "Light Civilian Reactor",
+      "MaxHP": "200",
+      "MinHP": "50",
+      "Crew": "5",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/Boosted Reactor",
+      "Name": "Boosted Reactor",
+      "MaxHP": "300",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/Large DC Storage",
+      "Name": "Large DC Storage",
+      "MaxHP": "300",
+      "MinHP": "10",
+      "Crew": "5",
+      "Restores": "4",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Citadel Magazine",
+      "Name": "Citadel Magazine",
+      "MaxHP": "300",
+      "MinHP": "20",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Damage Control Complex",
+      "Name": "Damage Control Complex",
+      "MaxHP": "600",
+      "MinHP": "20",
+      "Crew": "50",
+      "Restores": "2",
+      "Priority": "Low"
+    },
+    {
+      "Key": "Stock/Jury-Rigged Reactor",
+      "Name": "Jury-Rigged Reactor",
+      "MaxHP": "300",
+      "MinHP": "100",
+      "Crew": "30",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/BW800 Drive",
+      "Name": "BW800 Drive",
+      "MaxHP": "250",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/BW800-R Drive",
+      "Name": "BW800-R Drive",
+      "MaxHP": "400",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/BW1500 Drive",
+      "Name": "BW1500 Drive",
+      "MaxHP": "700",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/BW1500-R Drive",
+      "Name": "BW1500-R Drive",
+      "MaxHP": "1400",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/BW2000 Drive",
+      "Name": "BW2000 Drive",
+      "MaxHP": "700",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/CHI-777 Yard Drive",
+      "Name": "CHI-777 Yard Drive",
+      "MaxHP": "250",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/CHI-7700 Drive",
+      "Name": "CHI-7700 Drive",
+      "MaxHP": "700",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/CHI-9100 Long Haul Drive",
+      "Name": "CHI-9100 Long Haul Drive",
+      "MaxHP": "700",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/Sundrive Racing Pro",
+      "Name": "Sundrive Racing Pro",
+      "MaxHP": "100",
+      "MinHP": "50",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Critical"
+    },
+    {
+      "Key": "Stock/Ithaca Bridgemaster",
+      "Name": "Ithaca Bridgemaster",
+      "MaxHP": "200",
+      "MinHP": "30",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "High"
+    },
+    {
+      "Key": "Stock/Bulwark Huntress",
+      "Name": "Bulwark Huntress",
+      "MaxHP": "200",
+      "MinHP": "30",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "High"
+    },
+    {
+      "Key": "Stock/R550 Early Warning Radar",
+      "Name": "R550 Early Warning Radar",
+      "MaxHP": "150",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/R400 Radar",
+      "Name": "R400 'Bloodhound' LRT Radar",
+      "MaxHP": "200",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/RF44 'Pinpoint' Radar",
+      "Name": "RF44 'Pinpoint' Radar",
+      "MaxHP": "70",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/T20 Cannon",
+      "Name": "T20 Cannon",
+      "MaxHP": "150",
+      "MinHP": "10",
+      "Crew": "4",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/T30 Cannon",
+      "Name": "T30 Cannon",
+      "MaxHP": "200",
+      "MinHP": "10",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/T81 Plasma Cannon",
+      "Name": "T81 Plasma Cannon",
+      "MaxHP": "300",
+      "MinHP": "10",
+      "Crew": "15",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/C30 Cannon",
+      "Name": "C30 Cannon",
+      "MaxHP": "350",
+      "MinHP": "15",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/C53 Cannon",
+      "Name": "C53 Cannon",
+      "MaxHP": "300",
+      "MinHP": "15",
+      "Crew": "15",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/C54 Cannon",
+      "Name": "C56 Cannon",
+      "MaxHP": "350",
+      "MinHP": "15",
+      "Crew": "15",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/C65 Cannon",
+      "Name": "C65 Cannon",
+      "MaxHP": "500",
+      "MinHP": "20",
+      "Crew": "25",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/C81 Plasma Cannon",
+      "Name": "C81 Plasma Cannon",
+      "MaxHP": "500",
+      "MinHP": "20",
+      "Crew": "25",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/C90 Cannon",
+      "Name": "C90 Cannon",
+      "MaxHP": "500",
+      "MinHP": "30",
+      "Crew": "25",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/TE45 Mass Driver",
+      "Name": "TE45 Mass Driver",
+      "MaxHP": "450",
+      "MinHP": "20",
+      "Crew": "15",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/P11 PDT",
+      "Name": "P11 'Pavise' PDT",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "3",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/P20 Flak PDT",
+      "Name": "P20 'Bastion' PDT",
+      "MaxHP": "150",
+      "MinHP": "10",
+      "Crew": "5",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/P60 Laser PDT",
+      "Name": "P60 'Grazer' PDT",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/L50 Laser Dazzler",
+      "Name": "L50 'Blackjack' Laser Dazzler",
+      "MaxHP": "75",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/J15 Jammer",
+      "Name": "J15 'Bellbird' Jammer",
+      "MaxHP": "150",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/J360 Jammer",
+      "Name": "J360 'Lyrebird' Jammer",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/E20 'Lighthouse' Illuminator",
+      "Name": "E20 'Lighthouse' Illuminator",
+      "MaxHP": "75",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/RL18 Launcher",
+      "Name": "RL18 Launcher",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/RL36 Launcher",
+      "Name": "RL36 Launcher",
+      "MaxHP": "175",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/Container Bank Launcher",
+      "Name": "Container Bank Launcher",
+      "MaxHP": "500",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "High"
+    },
+    {
+      "Key": "Stock/Container Stack Launcher",
+      "Name": "Container Stack Launcher",
+      "MaxHP": "200",
+      "MinHP": "10",
+      "Crew": "0",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/MLS-2 Launcher",
+      "Name": "MLS-2 Launcher",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/MLS-3 Launcher",
+      "Name": "MLS-3 Launcher",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "12",
+      "Restores": "0",
+      "Priority": "Medium"
+    },
+    {
+      "Key": "Stock/ML-9 Mine Launcher",
+      "Name": "ML-9 Mine Launcher",
+      "MaxHP": "100",
+      "MinHP": "10",
+      "Crew": "10",
+      "Restores": "0",
+      "Priority": "High"
+    }
+  ]
+}

--- a/data/fleets/Azurite Squadron.fleet
+++ b/data/fleets/Azurite Squadron.fleet
@@ -4,15 +4,16 @@
   <Version>3</Version>
   <TotalPoints>3000</TotalPoints>
   <FactionKey>Stock/Protectorate</FactionKey>
-  <Description>Difficulty: &lt;color=green&gt;EASY&lt;/color&gt;
+  <Description>Difficulty: &lt;color=yellow&gt;MODERATE&lt;/color&gt;
 
-Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400 Tug to aid in piercing jamming. The Lineship has a mix of 450mm and 250mm cannons which can be brought to bear depending on the threat. You'll want to keep the two close together to defend against missile threats as alone they'll get picked off.</Description>
+Azurite Squadron features a fighting lineship and Ocello pair armed with cannons, partnered with an R400 tugboat to aid in piercing jamming. The lineship has a heavier cannon loadout than the Ocello, but a harder time bringing it to bear - aligning before the engagement with the hold heading command will prove useful. You'll also want to keep the two close together to defend against missile threats, with the spotting tugboat safely in the rear.</Description>
+  <SortOverrideOrder>4</SortOverrideOrder>
   <Ships>
     <Ship>
       <SaveID xsi:nil="true" />
       <Key>da410729-e79e-4924-ad05-56bd3c95f694</Key>
       <Name>Rose Soul</Name>
-      <Cost>1572</Cost>
+      <Cost>1585</Cost>
       <Callsign />
       <Number>586</Number>
       <SymbolOption>0</SymbolOption>
@@ -32,23 +33,51 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
         </HullSocket>
         <HullSocket>
           <Key>4v5e01-gEUiTNnQJevNpGg</Key>
-          <ComponentName>Stock/Mk95 'Sarissa' PDT</ComponentName>
+          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>o78jebL2nkezXdHJ6xA3WA</Key>
-          <ComponentName>Stock/Mk95 'Sarissa' PDT</ComponentName>
+          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>Gpm2KFKPCU-0ECKr0YsJAw</Key>
-          <ComponentName>Stock/E70 'Interruption' Jammer</ComponentName>
+          <ComponentName>Stock/VLS-1-46 Launcher</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
+            <MissileLoad>
+              <MagSaveData>
+                <MagazineKey>kWIFt_PS50CehXlY0Li5mw</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-123 Defender</MunitionKey>
+                <Quantity>35</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>_yNca5m-8kqHgFWjhC5u_g</MagazineKey>
+                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
+                <Quantity>7</Quantity>
+              </MagSaveData>
+            </MissileLoad>
+          </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>-lwFeyvDUECyC-AuVfATog</Key>
-          <ComponentName>Stock/J360 Jammer</ComponentName>
+          <ComponentName>Stock/VLS-1-46 Launcher</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
+            <MissileLoad>
+              <MagSaveData>
+                <MagazineKey>2o4EHcyt8EeWFQaJwy16Nw</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-123 Defender</MunitionKey>
+                <Quantity>35</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>lZbMXSt2hkWcr2JFcH6yqA</MagazineKey>
+                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
+                <Quantity>7</Quantity>
+              </MagSaveData>
+            </MissileLoad>
+          </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>rI5k7ytZH0S7yQLZnFB_nQ</Key>
-          <ComponentName>Stock/L50 Laser Dazzler</ComponentName>
+          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>0J9pyeFp6U6KMEAXiuNHHw</Key>
@@ -56,11 +85,11 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
         </HullSocket>
         <HullSocket>
           <Key>mP5XoHZ3Wk-DsFk3YLAxzg</Key>
-          <ComponentName>Stock/P60 Laser PDT</ComponentName>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>xe7LNTrStUuS8PMCn6KYsQ</Key>
-          <ComponentName>Stock/P60 Laser PDT</ComponentName>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>4NKBOsswyUGpVA-YP-T5ng</Key>
@@ -78,16 +107,16 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
                 <Quantity>375</Quantity>
               </MagSaveData>
               <MagSaveData>
-                <MagazineKey>3gyvUdJYXUuKleqbI-TM-Q</MagazineKey>
-                <MunitionKey>Stock/15mm Sandshot</MunitionKey>
-                <Quantity>200</Quantity>
+                <MagazineKey>zPM04epwVk-fvCMeZHomaQ</MagazineKey>
+                <MunitionKey>Stock/Flak Round</MunitionKey>
+                <Quantity>600</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>bzRgWNrBdE6BjUaGy8G1tg</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>foWiXJZCEEKQx0LmO1IMnw</Key>
@@ -103,11 +132,11 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
         </HullSocket>
         <HullSocket>
           <Key>q5iHLt9VEU-166x4NJmr4Q</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>vXXZA02qQEyreCSFbtLJOA</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>S03aWjfX90epbCcytu9_xw</Key>
@@ -115,7 +144,7 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
         </HullSocket>
         <HullSocket>
           <Key>aImgD6jcq0GZXRi5MmyeWw</Key>
-          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+          <ComponentName>Stock/Large DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>hjHxzsG5iUCkaG0eGd52bA</Key>
@@ -123,11 +152,11 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
         </HullSocket>
         <HullSocket>
           <Key>Fp6_NyEq1E-ZGeZxM9kjUg</Key>
-          <ComponentName>Stock/FM280 'Raider' Drive</ComponentName>
+          <ComponentName>Stock/Boosted Reactor</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>-XwaOMN6eUSsztvywrmXVQ</Key>
-          <ComponentName>Stock/Boosted Reactor</ComponentName>
+          <ComponentName>Stock/FM580 'Raider' Drive</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>26mxVeOdd0SB5ZSaG_hJ0w</Key>
@@ -166,21 +195,6 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
             <string>iJzzxinSN0uJIjrt9M3aGA</string>
           </MemberKeys>
         </WepGroup>
-        <WepGroup Name="OmiRadar jammer">
-          <MemberKeys>
-            <string>-lwFeyvDUECyC-AuVfATog</string>
-          </MemberKeys>
-        </WepGroup>
-        <WepGroup Name="Omicom Jam">
-          <MemberKeys>
-            <string>Gpm2KFKPCU-0ECKr0YsJAw</string>
-          </MemberKeys>
-        </WepGroup>
-        <WepGroup Name="EO">
-          <MemberKeys>
-            <string>rI5k7ytZH0S7yQLZnFB_nQ</string>
-          </MemberKeys>
-        </WepGroup>
       </WeaponGroups>
       <TemplateMissileTypes />
     </Ship>
@@ -188,7 +202,7 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
       <SaveID xsi:nil="true" />
       <Key>b33e4aa7-533d-4657-8e54-c6c190b4debe</Key>
       <Name>Abject Terror</Name>
-      <Cost>1166</Cost>
+      <Cost>1134</Cost>
       <Callsign />
       <Number>258</Number>
       <SymbolOption>0</SymbolOption>
@@ -244,20 +258,8 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
           <ComponentName>Stock/C65 Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>auQ7ijGeX0evdikZQeBxTg</Key>
-          <ComponentName>Stock/C53 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
           <Key>d3N-B_JnDUKAdVRBJ6nvFQ</Key>
           <ComponentName>Stock/C65 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>xvNT1_DYcUuSpU6rrmL_4A</Key>
-          <ComponentName>Stock/C53 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>t0T4CSAPnEq4rvHAVl84-Q</Key>
-          <ComponentName>Stock/C53 Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>grYBjxIS3E--lmrqenuK8A</Key>
@@ -268,20 +270,16 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
           <ComponentName>Stock/C65 Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>tcQfj6XOHUWFSAx_W0cc1A</Key>
-          <ComponentName>Stock/C53 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
           <Key>bxvsvg5znk6TqiIKq8H0kg</Key>
-          <ComponentName>Stock/P11 PDT</ComponentName>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>9EF9u0V1eUetleBnkQhHkA</Key>
-          <ComponentName>Stock/P11 PDT</ComponentName>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>I68tNng-K0yG-AoUx0HcSw</Key>
-          <ComponentName>Stock/P20 Flak PDT</ComponentName>
+          <ComponentName>Stock/P11 PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>Sb5-VSuwlkWpT6ViRiJ3vg</Key>
@@ -291,22 +289,27 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
               <MagSaveData>
                 <MagazineKey>wkafEDT7jEK9TeEtYVoCjw</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-123 Defender</MunitionKey>
-                <Quantity>40</Quantity>
+                <Quantity>30</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>dQyU52z-h0ipSyVhoEB5VA</MagazineKey>
+                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
+                <Quantity>16</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>6ZiODnoXqkaNWvaqyGjnwg</Key>
-          <ComponentName>Stock/P20 Flak PDT</ComponentName>
+          <ComponentName>Stock/P11 PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>87PSgg9GREmGU9MIRAXXhg</Key>
-          <ComponentName>Stock/P11 PDT</ComponentName>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>VDQhZPo-rkWkzwozat27fw</Key>
-          <ComponentName>Stock/P11 PDT</ComponentName>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>y1Cs8LR0KUyCKUAJBIOyOg</Key>
@@ -314,45 +317,35 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
         </HullSocket>
         <HullSocket>
           <Key>fYoX2amTl0KrZurPKjU9gg</Key>
-          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentName>Stock/Citadel Magazine</ComponentName>
           <ComponentData xsi:type="BulkMagazineData">
             <Load>
               <MagSaveData>
-                <MagazineKey>qg0dGebu8Ea7DqrfOXSvLg</MagazineKey>
+                <MagazineKey>Fg-WtFNWV0iRVLOjvn_mfw</MagazineKey>
                 <MunitionKey>Stock/20mm Slug</MunitionKey>
-                <Quantity>12000</Quantity>
+                <Quantity>16000</Quantity>
               </MagSaveData>
               <MagSaveData>
-                <MagazineKey>P7qKWnH6nEePDdptOVn9oQ</MagazineKey>
-                <MunitionKey>Stock/250mm AP Shell</MunitionKey>
-                <Quantity>200</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>-0B68voUZkGX_VyZHvjlaA</MagazineKey>
-                <MunitionKey>Stock/250mm HE Shell</MunitionKey>
-                <Quantity>200</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>ADhGkROWakGVgOJDsFq9dQ</MagazineKey>
+                <MagazineKey>_aBsy6av30qMaF5rNHRnlw</MagazineKey>
                 <MunitionKey>Stock/450mm AP Shell</MunitionKey>
                 <Quantity>300</Quantity>
               </MagSaveData>
               <MagSaveData>
-                <MagazineKey>akixVqHJG0uIavWsZ1fQVw</MagazineKey>
+                <MagazineKey>HLH3FIBJ7UCiOAh_7G9LkA</MagazineKey>
                 <MunitionKey>Stock/450mm HE Shell</MunitionKey>
-                <Quantity>300</Quantity>
+                <Quantity>400</Quantity>
               </MagSaveData>
               <MagSaveData>
-                <MagazineKey>vrMAdHzr5k-kCZGcCLQAUg</MagazineKey>
+                <MagazineKey>z7swNzDs_UmEY8QjsMQ7Yg</MagazineKey>
                 <MunitionKey>Stock/Flak Round</MunitionKey>
-                <Quantity>600</Quantity>
+                <Quantity>1275</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>3Ky8PvdxqUKMRXZa0xLF2A</Key>
-          <ComponentName>Stock/Large DC Storage</ComponentName>
+          <ComponentName>Stock/Damage Control Complex</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>T9TN0ZYumUaCxcSRjO_qTw</Key>
@@ -360,7 +353,7 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
         </HullSocket>
         <HullSocket>
           <Key>T4d-8WnA_UiHSJh6PXiXpA</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <ComponentName>Stock/Auxiliary Steering</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>6LpDL27QuEW0PZCm35Nx5w</Key>
@@ -372,19 +365,19 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
         </HullSocket>
         <HullSocket>
           <Key>FVcPIcV_00eu62NQQK3oLg</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>1FrTJ5o850ynlq4dRDmMbA</Key>
           <ComponentName>Stock/Reinforced CIC</ComponentName>
         </HullSocket>
         <HullSocket>
+          <Key>1FrTJ5o850ynlq4dRDmMbA</Key>
+          <ComponentName>Stock/Large DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
           <Key>vOzzHo4KfE60wZ3Q1s38GA</Key>
-          <ComponentName>Stock/CHI-777 Yard Drive</ComponentName>
+          <ComponentName>Stock/CHI-9100 Long Haul Drive</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>6evWdeLGT0uALe075-nhgw</Key>
-          <ComponentName>Stock/Sundrive Racing Pro</ComponentName>
+          <ComponentName>Stock/CHI-777 Yard Drive</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>JVCLf3RKKUOBEXaWWkVLMw</Key>
@@ -396,11 +389,11 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
         </HullSocket>
         <HullSocket>
           <Key>yryHYXgMWEy969gRuaDO6w</Key>
-          <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>MQyTgOLGCkyeljdvbkkFDA</Key>
-          <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>S-rQo19r20K0L0PRer3yMw</Key>
@@ -412,14 +405,6 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
         </HullSocket>
       </SocketMap>
       <WeaponGroups>
-        <WepGroup Name="250">
-          <MemberKeys>
-            <string>auQ7ijGeX0evdikZQeBxTg</string>
-            <string>xvNT1_DYcUuSpU6rrmL_4A</string>
-            <string>t0T4CSAPnEq4rvHAVl84-Q</string>
-            <string>tcQfj6XOHUWFSAx_W0cc1A</string>
-          </MemberKeys>
-        </WepGroup>
         <WepGroup Name="450">
           <MemberKeys>
             <string>d3N-B_JnDUKAdVRBJ6nvFQ</string>
@@ -435,7 +420,7 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
       <SaveID xsi:nil="true" />
       <Key>6b49867a-5f92-4992-aa29-8ce18138c9b7</Key>
       <Name>Always Alert</Name>
-      <Cost>262</Cost>
+      <Cost>281</Cost>
       <Callsign />
       <Number>611</Number>
       <SymbolOption>0</SymbolOption>
@@ -451,16 +436,21 @@ Frontline fighting Cannon Armed Lineship and Ocello pair, partnered with an R400
           <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>_6LNzD6W3U2TgEnrpJH8OA</MagazineKey>
-                <MunitionKey>$MODMIS$/SGM-112 Shield</MunitionKey>
-                <Quantity>16</Quantity>
+                <MagazineKey>l1P_shOSoEaeiYCrkX2_rA</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-123 Defender</MunitionKey>
+                <Quantity>15</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>6E_yv2BJn066Ax2yWPlcGw</MagazineKey>
+                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
+                <Quantity>6</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>F6bmJdCO3EqzXK9SBJoXUw</Key>
-          <ComponentName>Stock/Basic CIC</ComponentName>
+          <ComponentName>Stock/Reinforced CIC</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>-PqoLKimSUOZtKMLo5QHXg</Key>
@@ -510,12 +500,12 @@ Targeting Modes:
 	&lt;b&gt;&lt;color=#4CFF72&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
 Primary Seeker: ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
 
-303 m/s for 6,551 m, top speed in 0.8 s
+304 m/s for 2,325 m, top speed in 0.5 s
 Terminal Maneuvers: None
 
 Proximity Fuze, High Explosive, Blast Fragmentation
-Armor: 1cm   Component: 40hp
-Blast Radius: 33 m
+Armor: 2cm   Component: 65hp
+Blast Radius: 47 m
 
 Body Integrity: 10 
 Programming Time: 6 s
@@ -554,111 +544,33 @@ Failure Rate: 0 %</LongDescription>
           <InstalledComponent xsi:type="DirectGuidanceSettings">
             <ComponentKey>Stock/Direct Guidance</ComponentKey>
             <Role>Defensive</Role>
-            <HotLaunch>false</HotLaunch>
-            <SelfDestructOnLost>false</SelfDestructOnLost>
-            <Maneuvers>None</Maneuvers>
-            <DefensiveDoctrine>
-              <TargetSizeMask>8</TargetSizeMask>
-              <TargetSizeOrdering>Descending</TargetSizeOrdering>
-              <SalvoSize>1</SalvoSize>
-              <FarthestFirst>false</FarthestFirst>
-            </DefensiveDoctrine>
-            <ApproachAngleControl>true</ApproachAngleControl>
-          </InstalledComponent>
-        </MissileSocket>
-        <MissileSocket>
-          <Size>2</Size>
-          <InstalledComponent>
-            <ComponentKey>Stock/Blast Fragmentation</ComponentKey>
-          </InstalledComponent>
-        </MissileSocket>
-        <MissileSocket>
-          <Size>4</Size>
-          <InstalledComponent xsi:type="MissileEngineSettings">
-            <ComponentKey />
-            <BalanceValues>
-              <A>0.350815</A>
-              <B>0.585463166</B>
-              <C>0.0637218356</C>
-            </BalanceValues>
-          </InstalledComponent>
-        </MissileSocket>
-      </Sockets>
-    </MissileTemplate>
-    <MissileTemplate>
-      <AssociatedTemplateName>SGM-112 Shield</AssociatedTemplateName>
-      <Designation>SGM-112</Designation>
-      <Nickname>Shield</Nickname>
-      <Description>DIRECT - ACT(&lt;color=#4CFF72&gt;RADAR&lt;/color&gt;) - HE FRAG</Description>
-      <LongDescription>The SGM-112 Shield is a size 1 direct guidance missile.  It is based on the SGM-1 body, which is a nimble general-purpose missile.  This missile will deliver a Proximity Fuze, High Explosive, Blast Fragmentation warhead.  It homes in on its target using an Active Radar seeker.
-
-Control Method: DIRECT
-Targeting Modes:
-	&lt;b&gt;&lt;color=#4CFF72&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
-Primary Seeker: ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
-
-303 m/s for 6,551 m, top speed in 0.8 s
-Terminal Maneuvers: None
-
-Proximity Fuze, High Explosive, Blast Fragmentation
-Armor: 1cm   Component: 40hp
-Blast Radius: 33 m</LongDescription>
-      <Cost>2</Cost>
-      <BodyKey>Stock/SGM-1 Body</BodyKey>
-      <TemplateKey>8e6871dc-ae2d-42f5-a217-6662600d46cd</TemplateKey>
-      <BaseColor>
-        <r>1</r>
-        <g>0.4862745</g>
-        <b>0</b>
-        <a>1</a>
-      </BaseColor>
-      <StripeColor>
-        <r>0.254901975</r>
-        <g>0.254901975</g>
-        <b>0.254901975</b>
-        <a>1</a>
-      </StripeColor>
-      <Sockets>
-        <MissileSocket>
-          <Size>1</Size>
-          <InstalledComponent xsi:type="ActiveSeekerSettings">
-            <ComponentKey>Stock/Steerable Active Radar Seeker</ComponentKey>
-            <Mode>Targeting</Mode>
-            <RejectUnvalidated>false</RejectUnvalidated>
-            <DetectPDTargets>false</DetectPDTargets>
-          </InstalledComponent>
-        </MissileSocket>
-        <MissileSocket>
-          <Size>1</Size>
-          <InstalledComponent xsi:type="DirectGuidanceSettings">
-            <ComponentKey>Stock/Direct Guidance</ComponentKey>
-            <Role>Defensive</Role>
-            <HotLaunch>false</HotLaunch>
+            <HotLaunch>true</HotLaunch>
             <SelfDestructOnLost>false</SelfDestructOnLost>
             <Maneuvers>None</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>Hybrid</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
-              <SalvoSize>1</SalvoSize>
+              <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
             </DefensiveDoctrine>
             <ApproachAngleControl>true</ApproachAngleControl>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>2</Size>
+          <Size>4</Size>
           <InstalledComponent>
             <ComponentKey>Stock/Blast Fragmentation</ComponentKey>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>4</Size>
+          <Size>3</Size>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.350815</A>
-              <B>0.585463166</B>
-              <C>0.0637218356</C>
+              <A>0.360532731</A>
+              <B>0.106361784</B>
+              <C>0.5331055</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>

--- a/data/fleets/Cobalt Squadron.fleet
+++ b/data/fleets/Cobalt Squadron.fleet
@@ -1,0 +1,585 @@
+<?xml version="1.0"?>
+<Fleet xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <Name>Cobalt Squadron</Name>
+  <Version>3</Version>
+  <TotalPoints>3000</TotalPoints>
+  <FactionKey>Stock/Protectorate</FactionKey>
+  <Description>Difficulty: &lt;color=green&gt;EASY&lt;/color&gt;
+
+Heavily armoured and equipped for damage control, Cobalt Squadron is a durable firebase, able to hold the line against any target at medium range. With one concentrated formation, this fleet is ideal for those who struggle with multitasking, though it must be positioned well and pointed at incoming threats with a hold heading command - its flanks are vulnerable, and it lacks the mobility to escape an ambush.</Description>
+  <SortOverrideOrder>1</SortOverrideOrder>
+  <Ships>
+    <Ship>
+      <SaveID xsi:nil="true" />
+      <Key>375c83e1-ccd3-41b4-863a-7c9ea5aa5100</Key>
+      <Name>Some Assembly Required</Name>
+      <Cost>1476</Cost>
+      <Callsign />
+      <Number>540</Number>
+      <SymbolOption>0</SymbolOption>
+      <HullType>Stock/Ocello Cruiser</HullType>
+      <SocketMap>
+        <HullSocket>
+          <Key>iJzzxinSN0uJIjrt9M3aGA</Key>
+          <ComponentName>Stock/Mk66 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>lQ7GplJ1ikW0K_QhXK7GvA</Key>
+          <ComponentName>Stock/Mk66 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>60X-7VSlxUq6Qas-KwszMA</Key>
+          <ComponentName>Stock/Mk66 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>4v5e01-gEUiTNnQJevNpGg</Key>
+          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>o78jebL2nkezXdHJ6xA3WA</Key>
+          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>Gpm2KFKPCU-0ECKr0YsJAw</Key>
+          <ComponentName>Stock/VLS-1-46 Launcher</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
+            <MissileLoad>
+              <MagSaveData>
+                <MagazineKey>616eVs7arkez-5-QzzzTdw</MagazineKey>
+                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
+                <Quantity>15</Quantity>
+              </MagSaveData>
+            </MissileLoad>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>0J9pyeFp6U6KMEAXiuNHHw</Key>
+          <ComponentName>Stock/RF101 'Bullseye' Radar</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>mP5XoHZ3Wk-DsFk3YLAxzg</Key>
+          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>xe7LNTrStUuS8PMCn6KYsQ</Key>
+          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>4NKBOsswyUGpVA-YP-T5ng</Key>
+          <ComponentName>Stock/Berthing</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>bzRgWNrBdE6BjUaGy8G1tg</Key>
+          <ComponentName>Stock/Large DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>foWiXJZCEEKQx0LmO1IMnw</Key>
+          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>nN0ZLp_pnkilWoAlM6rk0A</MagazineKey>
+                <MunitionKey>Stock/450mm HE Shell</MunitionKey>
+                <Quantity>300</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>iiDgVQYtOEKT1Doaxq5NMA</MagazineKey>
+                <MunitionKey>Stock/450mm AP Shell</MunitionKey>
+                <Quantity>300</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>viC38BuOaEuyTlVDRdF0gg</Key>
+          <ComponentName>Stock/Reinforced CIC</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>GXIxYPfk8E2cbQnK0U1QNw</Key>
+          <ComponentName>Stock/Bulk Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>_aVqb0J3wkWAWkdSECar-Q</MagazineKey>
+                <MunitionKey>Stock/450mm HE Shell</MunitionKey>
+                <Quantity>225</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>SeRAyDxqykOIVP-8AS6RnQ</MagazineKey>
+                <MunitionKey>Stock/450mm AP Shell</MunitionKey>
+                <Quantity>225</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>q5iHLt9VEU-166x4NJmr4Q</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>vXXZA02qQEyreCSFbtLJOA</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>S03aWjfX90epbCcytu9_xw</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>aImgD6jcq0GZXRi5MmyeWw</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>hjHxzsG5iUCkaG0eGd52bA</Key>
+          <ComponentName>Stock/FR4800 Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>Fp6_NyEq1E-ZGeZxM9kjUg</Key>
+          <ComponentName>Stock/FR4800 Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>-XwaOMN6eUSsztvywrmXVQ</Key>
+          <ComponentName>Stock/FM500 Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>26mxVeOdd0SB5ZSaG_hJ0w</Key>
+          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>c2zMLaokmU6GUJMYfS3N_Q</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>t3_3a8clbky2DQa0g_ODgg</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>73x1IW-ccUSI_0bIcWMFPw</Key>
+          <ComponentName>Stock/RM50 'Parallax' Radar</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>LNhnTOaflUaLPxvcpEctGg</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>yPVEWDqw0EOqF2I5_u-ETA</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+      </SocketMap>
+      <WeaponGroups>
+        <WepGroup Name="Main Guns">
+          <MemberKeys>
+            <string>iJzzxinSN0uJIjrt9M3aGA</string>
+            <string>lQ7GplJ1ikW0K_QhXK7GvA</string>
+            <string>60X-7VSlxUq6Qas-KwszMA</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
+      <TemplateMissileTypes />
+    </Ship>
+    <Ship>
+      <SaveID xsi:nil="true" />
+      <Key>94cb2476-50e1-4e75-8198-7da1703e438e</Key>
+      <Name>No Refunds</Name>
+      <Cost>508</Cost>
+      <Callsign />
+      <Number>541</Number>
+      <SymbolOption>0</SymbolOption>
+      <HullType>Stock/Bulk Feeder</HullType>
+      <SocketMap>
+        <HullSocket>
+          <Key>4V6twrIUcEKE11tom-tDXQ</Key>
+          <ComponentName>Stock/C90 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>yN7f-9tEXEKlBNskqP6EbA</Key>
+          <ComponentName>Stock/T30 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>Z2uDs34J-ESu64-i9YGnxQ</Key>
+          <ComponentName>Stock/T30 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gb6_3kWBY0KlEWeex3ruDg</Key>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_y-Bd-EWjUeMIrmzG3UxvQ</Key>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gDQghm5iik2syYcoJqUPFg</Key>
+          <ComponentName>Stock/Reinforced CIC</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>vtme83CXg0qDA4_YK6NqwA</Key>
+          <ComponentName>Stock/Citadel Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>vqwml1rJO0ODEaq55-zDOA</MagazineKey>
+                <MunitionKey>Stock/600mm HE Shell</MunitionKey>
+                <Quantity>125</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>N3nkXfUjA0K0ALgSOREiPA</MagazineKey>
+                <MunitionKey>Stock/600mm Bomb Shell</MunitionKey>
+                <Quantity>100</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>6bG6AQ_C4Uyz9GviyTq4sw</MagazineKey>
+                <MunitionKey>Stock/100mm AP Shell</MunitionKey>
+                <Quantity>1000</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>SUP6KAUSV0Kup0nBVkvi6Q</MagazineKey>
+                <MunitionKey>Stock/100mm HE Shell</MunitionKey>
+                <Quantity>500</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>DkTRAxQLc0SSWUGc4vWeZw</MagazineKey>
+                <MunitionKey>Stock/Flak Round</MunitionKey>
+                <Quantity>600</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>TTM8O-MUDky06__LwvSo8w</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>rGVFgJ8GyUePoRkz33c1sw</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_hUvj899GkWP0bnjDN1ODw</Key>
+          <ComponentName>Stock/Berthing</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>N4KIOsNqeUGVAUrx5OW3DQ</Key>
+          <ComponentName>Stock/Large DC Storage</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>9K_1ZNCgFESrvaoQMOH3yw</Key>
+          <ComponentName>Stock/Civilian Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>HNv6B-78FEuhV8YT9A6uZw</Key>
+          <ComponentName>Stock/BW800 Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>HvdEBsnpUUypPN4uW67paQ</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>iDdlfFwKkUO9HbumzymceA</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>DaqWEX-8gEeIzYrhp8NIMw</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>EvZ6JN5xV0aUlKEeeKxFTQ</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>CU_oraqJxEaB3dTzZW2MkA</Key>
+          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
+        </HullSocket>
+      </SocketMap>
+      <WeaponGroups>
+        <WepGroup Name="Spinal Guns">
+          <MemberKeys>
+            <string>4V6twrIUcEKE11tom-tDXQ</string>
+          </MemberKeys>
+        </WepGroup>
+        <WepGroup Name="Light Guns">
+          <MemberKeys>
+            <string>yN7f-9tEXEKlBNskqP6EbA</string>
+            <string>Z2uDs34J-ESu64-i9YGnxQ</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
+      <InitialFormation>
+        <GuideKey>375c83e1-ccd3-41b4-863a-7c9ea5aa5100</GuideKey>
+        <RelativePosition>
+          <x>3.64780426E-05</x>
+          <y>-27.5515442</y>
+          <z>0.00402832031</z>
+        </RelativePosition>
+      </InitialFormation>
+      <TemplateMissileTypes />
+    </Ship>
+    <Ship>
+      <SaveID xsi:nil="true" />
+      <Key>25d42521-d965-4b5f-8ec0-695240e28a46</Key>
+      <Name>Read The Manual</Name>
+      <Cost>508</Cost>
+      <Callsign />
+      <Number>542</Number>
+      <SymbolOption>0</SymbolOption>
+      <HullType>Stock/Bulk Feeder</HullType>
+      <SocketMap>
+        <HullSocket>
+          <Key>4V6twrIUcEKE11tom-tDXQ</Key>
+          <ComponentName>Stock/C90 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>yN7f-9tEXEKlBNskqP6EbA</Key>
+          <ComponentName>Stock/T30 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>Z2uDs34J-ESu64-i9YGnxQ</Key>
+          <ComponentName>Stock/T30 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gb6_3kWBY0KlEWeex3ruDg</Key>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_y-Bd-EWjUeMIrmzG3UxvQ</Key>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gDQghm5iik2syYcoJqUPFg</Key>
+          <ComponentName>Stock/Reinforced CIC</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>vtme83CXg0qDA4_YK6NqwA</Key>
+          <ComponentName>Stock/Citadel Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>oDOnRHHJhUC0PIMT1WV3dg</MagazineKey>
+                <MunitionKey>Stock/600mm HE Shell</MunitionKey>
+                <Quantity>125</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>xUQKha7ah0y4JF-0NmD4YQ</MagazineKey>
+                <MunitionKey>Stock/600mm Bomb Shell</MunitionKey>
+                <Quantity>100</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>pcfO2ycIFUOjLUIepbFZHA</MagazineKey>
+                <MunitionKey>Stock/100mm AP Shell</MunitionKey>
+                <Quantity>1000</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>b0jLE6LSREaeI8TZrgRIQw</MagazineKey>
+                <MunitionKey>Stock/100mm HE Shell</MunitionKey>
+                <Quantity>500</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>RSRPP86U_USYKbQ0F7f41w</MagazineKey>
+                <MunitionKey>Stock/Flak Round</MunitionKey>
+                <Quantity>600</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>TTM8O-MUDky06__LwvSo8w</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>rGVFgJ8GyUePoRkz33c1sw</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_hUvj899GkWP0bnjDN1ODw</Key>
+          <ComponentName>Stock/Berthing</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>N4KIOsNqeUGVAUrx5OW3DQ</Key>
+          <ComponentName>Stock/Large DC Storage</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>9K_1ZNCgFESrvaoQMOH3yw</Key>
+          <ComponentName>Stock/Civilian Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>HNv6B-78FEuhV8YT9A6uZw</Key>
+          <ComponentName>Stock/BW800 Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>HvdEBsnpUUypPN4uW67paQ</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>iDdlfFwKkUO9HbumzymceA</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>DaqWEX-8gEeIzYrhp8NIMw</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>EvZ6JN5xV0aUlKEeeKxFTQ</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>CU_oraqJxEaB3dTzZW2MkA</Key>
+          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
+        </HullSocket>
+      </SocketMap>
+      <WeaponGroups>
+        <WepGroup Name="Spinal Guns">
+          <MemberKeys>
+            <string>4V6twrIUcEKE11tom-tDXQ</string>
+          </MemberKeys>
+        </WepGroup>
+        <WepGroup Name="Light Guns">
+          <MemberKeys>
+            <string>yN7f-9tEXEKlBNskqP6EbA</string>
+            <string>Z2uDs34J-ESu64-i9YGnxQ</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
+      <InitialFormation>
+        <GuideKey>375c83e1-ccd3-41b4-863a-7c9ea5aa5100</GuideKey>
+        <RelativePosition>
+          <x>27.9755974</x>
+          <y>13.3011169</y>
+          <z>0.160873413</z>
+        </RelativePosition>
+      </InitialFormation>
+      <TemplateMissileTypes />
+    </Ship>
+    <Ship>
+      <SaveID xsi:nil="true" />
+      <Key>ec6f1fbc-a88d-423b-8bdf-1fa882f99898</Key>
+      <Name>Not For Sale</Name>
+      <Cost>508</Cost>
+      <Callsign />
+      <Number>543</Number>
+      <SymbolOption>0</SymbolOption>
+      <HullType>Stock/Bulk Feeder</HullType>
+      <SocketMap>
+        <HullSocket>
+          <Key>4V6twrIUcEKE11tom-tDXQ</Key>
+          <ComponentName>Stock/C90 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>yN7f-9tEXEKlBNskqP6EbA</Key>
+          <ComponentName>Stock/T30 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>Z2uDs34J-ESu64-i9YGnxQ</Key>
+          <ComponentName>Stock/T30 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gb6_3kWBY0KlEWeex3ruDg</Key>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_y-Bd-EWjUeMIrmzG3UxvQ</Key>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gDQghm5iik2syYcoJqUPFg</Key>
+          <ComponentName>Stock/Reinforced CIC</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>vtme83CXg0qDA4_YK6NqwA</Key>
+          <ComponentName>Stock/Citadel Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>1GCrkGSbGkqvPjkhcFdQ7Q</MagazineKey>
+                <MunitionKey>Stock/600mm HE Shell</MunitionKey>
+                <Quantity>125</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>Gr6eMx4hDEa_fTHABgCTjg</MagazineKey>
+                <MunitionKey>Stock/600mm Bomb Shell</MunitionKey>
+                <Quantity>100</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>Q1RXt4rP1ESU23c3Ke9zIg</MagazineKey>
+                <MunitionKey>Stock/100mm AP Shell</MunitionKey>
+                <Quantity>1000</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>6h8EmZtUFUqXie_q3KWafA</MagazineKey>
+                <MunitionKey>Stock/100mm HE Shell</MunitionKey>
+                <Quantity>500</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>6mJ93wWRlUy-GkbjT9IlWA</MagazineKey>
+                <MunitionKey>Stock/Flak Round</MunitionKey>
+                <Quantity>600</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>TTM8O-MUDky06__LwvSo8w</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>rGVFgJ8GyUePoRkz33c1sw</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_hUvj899GkWP0bnjDN1ODw</Key>
+          <ComponentName>Stock/Berthing</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>N4KIOsNqeUGVAUrx5OW3DQ</Key>
+          <ComponentName>Stock/Large DC Storage</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>9K_1ZNCgFESrvaoQMOH3yw</Key>
+          <ComponentName>Stock/Civilian Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>HNv6B-78FEuhV8YT9A6uZw</Key>
+          <ComponentName>Stock/BW800 Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>HvdEBsnpUUypPN4uW67paQ</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>iDdlfFwKkUO9HbumzymceA</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>DaqWEX-8gEeIzYrhp8NIMw</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>EvZ6JN5xV0aUlKEeeKxFTQ</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>CU_oraqJxEaB3dTzZW2MkA</Key>
+          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
+        </HullSocket>
+      </SocketMap>
+      <WeaponGroups>
+        <WepGroup Name="Spinal Guns">
+          <MemberKeys>
+            <string>4V6twrIUcEKE11tom-tDXQ</string>
+          </MemberKeys>
+        </WepGroup>
+        <WepGroup Name="Light Guns">
+          <MemberKeys>
+            <string>yN7f-9tEXEKlBNskqP6EbA</string>
+            <string>Z2uDs34J-ESu64-i9YGnxQ</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
+      <InitialFormation>
+        <GuideKey>375c83e1-ccd3-41b4-863a-7c9ea5aa5100</GuideKey>
+        <RelativePosition>
+          <x>-28.0033817</x>
+          <y>13.3747864</y>
+          <z>-0.333297729</z>
+        </RelativePosition>
+      </InitialFormation>
+      <TemplateMissileTypes />
+    </Ship>
+  </Ships>
+</Fleet>

--- a/data/fleets/Garnet Squadron.fleet
+++ b/data/fleets/Garnet Squadron.fleet
@@ -4,15 +4,429 @@
   <Version>3</Version>
   <TotalPoints>3000</TotalPoints>
   <FactionKey>Stock/Protectorate</FactionKey>
-  <Description>Difficulty: &lt;color=green&gt;EASY&lt;/color&gt;
+  <Description>Difficulty: &lt;color=yellow&gt;MODERATE&lt;/color&gt;
 
-A quartet of Plasma and T30 Monitors form the core of an easy to use all purpose fleet. No expense is spared on damage control or point defense, resulting in an above average level of toughness well suited to pushing and brawling. To round out the utility a pair of EWR/LRT tugs provide radar support and are likewise armed with extensive PD.</Description>
+Garnet Squadron is a multi-role heavy attack fleet featuring a swarm of monitors. The C90 cannon forms the backbone of the fleet, and its 600mm bombs combined with 100mm fire will quickly shred any lightly armored foe. Against heavy targets, swap to 600mm HE-SH and call in support fire from the plasma cannons. Once the target is nice and crispy, 100mm HE-HC shells can devastate even the mightiest ship. To prevent being caught out in the open, a pair of jammers should be used with battle-short. The EWR tugboat can help you plan ambushes, but keep it safe in the rear, as it lacks layered defenses. Success with Garnet depends on choosing ammo types to suit your targets and engaging on your terms.</Description>
+  <SortOverrideOrder>3</SortOverrideOrder>
   <Ships>
     <Ship>
       <SaveID xsi:nil="true" />
+      <Key>224e5998-56d0-4c78-9859-5e7f1d7a1473</Key>
+      <Name>See It My Way</Name>
+      <Cost>616</Cost>
+      <Callsign />
+      <Number>1439</Number>
+      <SymbolOption>0</SymbolOption>
+      <HullType>Stock/Bulk Feeder</HullType>
+      <SocketMap>
+        <HullSocket>
+          <Key>4V6twrIUcEKE11tom-tDXQ</Key>
+          <ComponentName>Stock/C90 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>yN7f-9tEXEKlBNskqP6EbA</Key>
+          <ComponentName>Stock/T30 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>Z2uDs34J-ESu64-i9YGnxQ</Key>
+          <ComponentName>Stock/T30 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gb6_3kWBY0KlEWeex3ruDg</Key>
+          <ComponentName>Stock/J15 Jammer</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_y-Bd-EWjUeMIrmzG3UxvQ</Key>
+          <ComponentName>Stock/J15 Jammer</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gDQghm5iik2syYcoJqUPFg</Key>
+          <ComponentName>Stock/Reinforced CIC</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>vtme83CXg0qDA4_YK6NqwA</Key>
+          <ComponentName>Stock/Citadel Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>CzA4LWaOZkq1lhmcBlDtEA</MagazineKey>
+                <MunitionKey>Stock/100mm AP Shell</MunitionKey>
+                <Quantity>500</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>6PDeYjmayk-DPthtJnbFEw</MagazineKey>
+                <MunitionKey>Stock/100mm HE Shell</MunitionKey>
+                <Quantity>500</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>Z4QOeHoX6Em53WaTcForwQ</MagazineKey>
+                <MunitionKey>Stock/100mm HE-HC Shell</MunitionKey>
+                <Quantity>250</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>7ehNfQLSmUOK261qTyveAQ</MagazineKey>
+                <MunitionKey>Stock/600mm HE Shell</MunitionKey>
+                <Quantity>100</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>NydEkOWW0EaD0vWy_TKR4A</MagazineKey>
+                <MunitionKey>Stock/600mm Bomb Shell</MunitionKey>
+                <Quantity>50</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>TTM8O-MUDky06__LwvSo8w</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>rGVFgJ8GyUePoRkz33c1sw</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_hUvj899GkWP0bnjDN1ODw</Key>
+          <ComponentName>Stock/Berthing</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>N4KIOsNqeUGVAUrx5OW3DQ</Key>
+          <ComponentName>Stock/Damage Control Complex</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>9K_1ZNCgFESrvaoQMOH3yw</Key>
+          <ComponentName>Stock/Civilian Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>HNv6B-78FEuhV8YT9A6uZw</Key>
+          <ComponentName>Stock/BW800 Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>HvdEBsnpUUypPN4uW67paQ</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>iDdlfFwKkUO9HbumzymceA</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>DaqWEX-8gEeIzYrhp8NIMw</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>EvZ6JN5xV0aUlKEeeKxFTQ</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>CU_oraqJxEaB3dTzZW2MkA</Key>
+          <ComponentName>Stock/Actively Cooled Amplifiers</ComponentName>
+        </HullSocket>
+      </SocketMap>
+      <WeaponGroups>
+        <WepGroup Name="T30">
+          <MemberKeys>
+            <string>yN7f-9tEXEKlBNskqP6EbA</string>
+            <string>Z2uDs34J-ESu64-i9YGnxQ</string>
+          </MemberKeys>
+        </WepGroup>
+        <WepGroup Name="Cannon">
+          <MemberKeys>
+            <string>4V6twrIUcEKE11tom-tDXQ</string>
+          </MemberKeys>
+        </WepGroup>
+        <WepGroup Name="Raspberry">
+          <MemberKeys>
+            <string>_y-Bd-EWjUeMIrmzG3UxvQ</string>
+            <string>gb6_3kWBY0KlEWeex3ruDg</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
+      <TemplateMissileTypes />
+    </Ship>
+    <Ship>
+      <SaveID xsi:nil="true" />
+      <Key>e6b741ce-1c47-4839-ba74-7d0c12c48d54</Key>
+      <Name>Right Scary</Name>
+      <Cost>513</Cost>
+      <Callsign />
+      <Number>1337</Number>
+      <SymbolOption>0</SymbolOption>
+      <HullType>Stock/Bulk Feeder</HullType>
+      <SocketMap>
+        <HullSocket>
+          <Key>4V6twrIUcEKE11tom-tDXQ</Key>
+          <ComponentName>Stock/C90 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>yN7f-9tEXEKlBNskqP6EbA</Key>
+          <ComponentName>Stock/T30 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>Z2uDs34J-ESu64-i9YGnxQ</Key>
+          <ComponentName>Stock/T30 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gb6_3kWBY0KlEWeex3ruDg</Key>
+          <ComponentName>Stock/P11 PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_y-Bd-EWjUeMIrmzG3UxvQ</Key>
+          <ComponentName>Stock/P11 PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gDQghm5iik2syYcoJqUPFg</Key>
+          <ComponentName>Stock/Reinforced CIC</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>vtme83CXg0qDA4_YK6NqwA</Key>
+          <ComponentName>Stock/Citadel Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>CzA4LWaOZkq1lhmcBlDtEA</MagazineKey>
+                <MunitionKey>Stock/100mm AP Shell</MunitionKey>
+                <Quantity>500</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>6PDeYjmayk-DPthtJnbFEw</MagazineKey>
+                <MunitionKey>Stock/100mm HE Shell</MunitionKey>
+                <Quantity>500</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>Z4QOeHoX6Em53WaTcForwQ</MagazineKey>
+                <MunitionKey>Stock/100mm HE-HC Shell</MunitionKey>
+                <Quantity>250</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>7ehNfQLSmUOK261qTyveAQ</MagazineKey>
+                <MunitionKey>Stock/600mm HE Shell</MunitionKey>
+                <Quantity>100</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>NydEkOWW0EaD0vWy_TKR4A</MagazineKey>
+                <MunitionKey>Stock/600mm Bomb Shell</MunitionKey>
+                <Quantity>50</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>cMsZuF8Q3ki17dsHfdKfhw</MagazineKey>
+                <MunitionKey>Stock/20mm Slug</MunitionKey>
+                <Quantity>14000</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>TTM8O-MUDky06__LwvSo8w</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>rGVFgJ8GyUePoRkz33c1sw</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_hUvj899GkWP0bnjDN1ODw</Key>
+          <ComponentName>Stock/Berthing</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>N4KIOsNqeUGVAUrx5OW3DQ</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>9K_1ZNCgFESrvaoQMOH3yw</Key>
+          <ComponentName>Stock/Civilian Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>HNv6B-78FEuhV8YT9A6uZw</Key>
+          <ComponentName>Stock/BW800 Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>HvdEBsnpUUypPN4uW67paQ</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>iDdlfFwKkUO9HbumzymceA</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>DaqWEX-8gEeIzYrhp8NIMw</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>EvZ6JN5xV0aUlKEeeKxFTQ</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>CU_oraqJxEaB3dTzZW2MkA</Key>
+          <ComponentName>Stock/Bulwark Huntress</ComponentName>
+        </HullSocket>
+      </SocketMap>
+      <WeaponGroups>
+        <WepGroup Name="T30">
+          <MemberKeys>
+            <string>yN7f-9tEXEKlBNskqP6EbA</string>
+            <string>Z2uDs34J-ESu64-i9YGnxQ</string>
+          </MemberKeys>
+        </WepGroup>
+        <WepGroup Name="Cannon">
+          <MemberKeys>
+            <string>4V6twrIUcEKE11tom-tDXQ</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
+      <InitialFormation>
+        <GuideKey>224e5998-56d0-4c78-9859-5e7f1d7a1473</GuideKey>
+        <RelativePosition>
+          <x>-30.059166</x>
+          <y>0</y>
+          <z>0.0708770752</z>
+        </RelativePosition>
+      </InitialFormation>
+      <TemplateMissileTypes />
+    </Ship>
+    <Ship>
+      <SaveID xsi:nil="true" />
+      <Key>a99d1e1c-e237-48a1-8c5b-fd840271f867</Key>
+      <Name>Tasty Pains</Name>
+      <Cost>513</Cost>
+      <Callsign />
+      <Number>375</Number>
+      <SymbolOption>0</SymbolOption>
+      <HullType>Stock/Bulk Feeder</HullType>
+      <SocketMap>
+        <HullSocket>
+          <Key>4V6twrIUcEKE11tom-tDXQ</Key>
+          <ComponentName>Stock/C90 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>yN7f-9tEXEKlBNskqP6EbA</Key>
+          <ComponentName>Stock/T30 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>Z2uDs34J-ESu64-i9YGnxQ</Key>
+          <ComponentName>Stock/T30 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gb6_3kWBY0KlEWeex3ruDg</Key>
+          <ComponentName>Stock/P11 PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_y-Bd-EWjUeMIrmzG3UxvQ</Key>
+          <ComponentName>Stock/P11 PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gDQghm5iik2syYcoJqUPFg</Key>
+          <ComponentName>Stock/Reinforced CIC</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>vtme83CXg0qDA4_YK6NqwA</Key>
+          <ComponentName>Stock/Citadel Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>CzA4LWaOZkq1lhmcBlDtEA</MagazineKey>
+                <MunitionKey>Stock/100mm AP Shell</MunitionKey>
+                <Quantity>500</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>6PDeYjmayk-DPthtJnbFEw</MagazineKey>
+                <MunitionKey>Stock/100mm HE Shell</MunitionKey>
+                <Quantity>500</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>Z4QOeHoX6Em53WaTcForwQ</MagazineKey>
+                <MunitionKey>Stock/100mm HE-HC Shell</MunitionKey>
+                <Quantity>250</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>7ehNfQLSmUOK261qTyveAQ</MagazineKey>
+                <MunitionKey>Stock/600mm HE Shell</MunitionKey>
+                <Quantity>100</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>NydEkOWW0EaD0vWy_TKR4A</MagazineKey>
+                <MunitionKey>Stock/600mm Bomb Shell</MunitionKey>
+                <Quantity>50</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>mjx8AC3YMkuBaJ0PJQf5uQ</MagazineKey>
+                <MunitionKey>Stock/20mm Slug</MunitionKey>
+                <Quantity>14000</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>TTM8O-MUDky06__LwvSo8w</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>rGVFgJ8GyUePoRkz33c1sw</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_hUvj899GkWP0bnjDN1ODw</Key>
+          <ComponentName>Stock/Berthing</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>N4KIOsNqeUGVAUrx5OW3DQ</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>9K_1ZNCgFESrvaoQMOH3yw</Key>
+          <ComponentName>Stock/Civilian Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>HNv6B-78FEuhV8YT9A6uZw</Key>
+          <ComponentName>Stock/BW800 Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>HvdEBsnpUUypPN4uW67paQ</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>iDdlfFwKkUO9HbumzymceA</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>DaqWEX-8gEeIzYrhp8NIMw</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>EvZ6JN5xV0aUlKEeeKxFTQ</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>CU_oraqJxEaB3dTzZW2MkA</Key>
+          <ComponentName>Stock/Bulwark Huntress</ComponentName>
+        </HullSocket>
+      </SocketMap>
+      <WeaponGroups>
+        <WepGroup Name="T30">
+          <MemberKeys>
+            <string>yN7f-9tEXEKlBNskqP6EbA</string>
+            <string>Z2uDs34J-ESu64-i9YGnxQ</string>
+          </MemberKeys>
+        </WepGroup>
+        <WepGroup Name="Cannon">
+          <MemberKeys>
+            <string>4V6twrIUcEKE11tom-tDXQ</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
+      <InitialFormation>
+        <GuideKey>224e5998-56d0-4c78-9859-5e7f1d7a1473</GuideKey>
+        <RelativePosition>
+          <x>30.167305</x>
+          <y>0</y>
+          <z>0.195999146</z>
+        </RelativePosition>
+      </InitialFormation>
+      <TemplateMissileTypes />
+    </Ship>
+    <Ship>
+      <SaveID xsi:nil="true" />
       <Key>e70ec13d-8565-4e92-b4fe-f0238b8d2d3a</Key>
-      <Name>Echo of Desdemona</Name>
-      <Cost>590</Cost>
+      <Name>Any Port in a Storm</Name>
+      <Cost>570</Cost>
       <Callsign />
       <Number>2</Number>
       <SymbolOption>0</SymbolOption>
@@ -20,37 +434,23 @@ A quartet of Plasma and T30 Monitors form the core of an easy to use all purpose
       <SocketMap>
         <HullSocket>
           <Key>4V6twrIUcEKE11tom-tDXQ</Key>
-          <ComponentName>Stock/C81 Plasma Cannon</ComponentName>
+          <ComponentName>Stock/C54 Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>yN7f-9tEXEKlBNskqP6EbA</Key>
-          <ComponentName>Stock/T30 Cannon</ComponentName>
+          <ComponentName>Stock/T81 Plasma Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>Z2uDs34J-ESu64-i9YGnxQ</Key>
-          <ComponentName>Stock/T30 Cannon</ComponentName>
+          <ComponentName>Stock/T81 Plasma Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>gb6_3kWBY0KlEWeex3ruDg</Key>
-          <ComponentName>Stock/RF44 'Pinpoint' Radar</ComponentName>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>_y-Bd-EWjUeMIrmzG3UxvQ</Key>
-          <ComponentName>Stock/VLS-1-46 Launcher</ComponentName>
-          <ComponentData xsi:type="CellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>14RuIfyPukufLsd1PwRbOA</MagazineKey>
-                <MunitionKey>$MODMIS$/SGM-112 Parry</MunitionKey>
-                <Quantity>34</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>m_fBidFUg0GioPRFNHjMSg</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>8</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-          </ComponentData>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>gDQghm5iik2syYcoJqUPFg</Key>
@@ -58,39 +458,39 @@ A quartet of Plasma and T30 Monitors form the core of an easy to use all purpose
         </HullSocket>
         <HullSocket>
           <Key>vtme83CXg0qDA4_YK6NqwA</Key>
-          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentName>Stock/Citadel Magazine</ComponentName>
           <ComponentData xsi:type="BulkMagazineData">
             <Load>
               <MagSaveData>
-                <MagazineKey>Dp5ZjV5lLEqjTnB6wHMcLw</MagazineKey>
-                <MunitionKey>Stock/100mm HE-HC Shell</MunitionKey>
-                <Quantity>1000</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>Pe7LL3LnL0S4fs8Y1UkKzQ</MagazineKey>
-                <MunitionKey>Stock/100mm HE Shell</MunitionKey>
-                <Quantity>300</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>WBJjVKPsEEqFkPRkNELmBA</MagazineKey>
-                <MunitionKey>Stock/100mm AP Shell</MunitionKey>
+                <MagazineKey>KT0DgU0u-kKffMUQLio5_A</MagazineKey>
+                <MunitionKey>Stock/400mm Plasma Ampoule</MunitionKey>
                 <Quantity>200</Quantity>
               </MagSaveData>
               <MagSaveData>
-                <MagazineKey>xaj-Lqnp-kG13_XRPdnokg</MagazineKey>
-                <MunitionKey>Stock/400mm Plasma Ampoule</MunitionKey>
-                <Quantity>100</Quantity>
+                <MagazineKey>jJZVsNkjx0yVS-vBRKYgYQ</MagazineKey>
+                <MunitionKey>Stock/Flak Round</MunitionKey>
+                <Quantity>450</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>TKZLK5hM_kiI6TJ1BXdZ-Q</MagazineKey>
+                <MunitionKey>Stock/250mm AP Shell</MunitionKey>
+                <Quantity>150</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>uDW4iR2Qv0e8fCLE-Y2h_w</MagazineKey>
+                <MunitionKey>Stock/250mm HE Shell</MunitionKey>
+                <Quantity>150</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>TTM8O-MUDky06__LwvSo8w</Key>
-          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>rGVFgJ8GyUePoRkz33c1sw</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>_hUvj899GkWP0bnjDN1ODw</Key>
@@ -98,121 +498,7 @@ A quartet of Plasma and T30 Monitors form the core of an easy to use all purpose
         </HullSocket>
         <HullSocket>
           <Key>N4KIOsNqeUGVAUrx5OW3DQ</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>9K_1ZNCgFESrvaoQMOH3yw</Key>
-          <ComponentName>Stock/Civilian Reactor</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>HNv6B-78FEuhV8YT9A6uZw</Key>
-          <ComponentName>Stock/CHI-777 Yard Drive</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>HvdEBsnpUUypPN4uW67paQ</Key>
-          <ComponentName>Stock/Bulwark Huntress</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>iDdlfFwKkUO9HbumzymceA</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>DaqWEX-8gEeIzYrhp8NIMw</Key>
-          <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
-        </HullSocket>
-      </SocketMap>
-      <WeaponGroups>
-        <WepGroup Name="Gun">
-          <MemberKeys>
-            <string>yN7f-9tEXEKlBNskqP6EbA</string>
-            <string>Z2uDs34J-ESu64-i9YGnxQ</string>
-          </MemberKeys>
-        </WepGroup>
-        <WepGroup Name="Plas">
-          <MemberKeys>
-            <string>4V6twrIUcEKE11tom-tDXQ</string>
-          </MemberKeys>
-        </WepGroup>
-      </WeaponGroups>
-      <TemplateMissileTypes />
-    </Ship>
-    <Ship>
-      <SaveID xsi:nil="true" />
-      <Key>4a7102c2-7e1a-4087-8dcb-657dabd52cfd</Key>
-      <Name>Tasty Pains</Name>
-      <Cost>559</Cost>
-      <Callsign />
-      <Number>977</Number>
-      <SymbolOption>0</SymbolOption>
-      <HullType>Stock/Bulk Feeder</HullType>
-      <SocketMap>
-        <HullSocket>
-          <Key>4V6twrIUcEKE11tom-tDXQ</Key>
-          <ComponentName>Stock/C81 Plasma Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>yN7f-9tEXEKlBNskqP6EbA</Key>
-          <ComponentName>Stock/T30 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>Z2uDs34J-ESu64-i9YGnxQ</Key>
-          <ComponentName>Stock/T30 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>gb6_3kWBY0KlEWeex3ruDg</Key>
-          <ComponentName>Stock/P60 Laser PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>_y-Bd-EWjUeMIrmzG3UxvQ</Key>
-          <ComponentName>Stock/P60 Laser PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>gDQghm5iik2syYcoJqUPFg</Key>
-          <ComponentName>Stock/Reinforced CIC</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>vtme83CXg0qDA4_YK6NqwA</Key>
-          <ComponentName>Stock/Reinforced Magazine</ComponentName>
-          <ComponentData xsi:type="BulkMagazineData">
-            <Load>
-              <MagSaveData>
-                <MagazineKey>Dp5ZjV5lLEqjTnB6wHMcLw</MagazineKey>
-                <MunitionKey>Stock/100mm HE-HC Shell</MunitionKey>
-                <Quantity>1000</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>Pe7LL3LnL0S4fs8Y1UkKzQ</MagazineKey>
-                <MunitionKey>Stock/100mm HE Shell</MunitionKey>
-                <Quantity>300</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>WBJjVKPsEEqFkPRkNELmBA</MagazineKey>
-                <MunitionKey>Stock/100mm AP Shell</MunitionKey>
-                <Quantity>200</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>xaj-Lqnp-kG13_XRPdnokg</MagazineKey>
-                <MunitionKey>Stock/400mm Plasma Ampoule</MunitionKey>
-                <Quantity>100</Quantity>
-              </MagSaveData>
-            </Load>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>TTM8O-MUDky06__LwvSo8w</Key>
-          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>rGVFgJ8GyUePoRkz33c1sw</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>_hUvj899GkWP0bnjDN1ODw</Key>
-          <ComponentName>Stock/Berthing</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>N4KIOsNqeUGVAUrx5OW3DQ</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <ComponentName>Stock/Damage Control Complex</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>9K_1ZNCgFESrvaoQMOH3yw</Key>
@@ -220,192 +506,73 @@ A quartet of Plasma and T30 Monitors form the core of an easy to use all purpose
         </HullSocket>
         <HullSocket>
           <Key>HNv6B-78FEuhV8YT9A6uZw</Key>
-          <ComponentName>Stock/CHI-777 Yard Drive</ComponentName>
+          <ComponentName>Stock/BW800 Drive</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>HvdEBsnpUUypPN4uW67paQ</Key>
-          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
+          <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>iDdlfFwKkUO9HbumzymceA</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+          <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>DaqWEX-8gEeIzYrhp8NIMw</Key>
           <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
         </HullSocket>
+        <HullSocket>
+          <Key>EvZ6JN5xV0aUlKEeeKxFTQ</Key>
+          <ComponentName>Stock/Small Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>CU_oraqJxEaB3dTzZW2MkA</Key>
+          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
+        </HullSocket>
       </SocketMap>
       <WeaponGroups>
-        <WepGroup Name="Gun">
+        <WepGroup Name="Plasma">
           <MemberKeys>
             <string>yN7f-9tEXEKlBNskqP6EbA</string>
             <string>Z2uDs34J-ESu64-i9YGnxQ</string>
           </MemberKeys>
         </WepGroup>
-        <WepGroup Name="Plas">
+        <WepGroup Name="250">
           <MemberKeys>
             <string>4V6twrIUcEKE11tom-tDXQ</string>
           </MemberKeys>
         </WepGroup>
       </WeaponGroups>
       <InitialFormation>
-        <GuideKey>e70ec13d-8565-4e92-b4fe-f0238b8d2d3a</GuideKey>
+        <GuideKey>224e5998-56d0-4c78-9859-5e7f1d7a1473</GuideKey>
         <RelativePosition>
-          <x>-23.6332626</x>
-          <y>-18.5322952</y>
-          <z>-0.424118042</z>
+          <x>-0.105554581</x>
+          <y>30.2919922</y>
+          <z>0.393234253</z>
         </RelativePosition>
       </InitialFormation>
       <TemplateMissileTypes />
     </Ship>
     <Ship>
       <SaveID xsi:nil="true" />
-      <Key>2e16b1b0-c024-40d8-90ef-d2850b6bb718</Key>
-      <Name>Right Scary</Name>
-      <Cost>529</Cost>
+      <Key>407ccc96-a909-405e-9cf0-ca350bf5e837</Key>
+      <Name>Open for Business</Name>
+      <Cost>570</Cost>
       <Callsign />
-      <Number>570</Number>
+      <Number>436</Number>
       <SymbolOption>0</SymbolOption>
       <HullType>Stock/Bulk Feeder</HullType>
       <SocketMap>
         <HullSocket>
           <Key>4V6twrIUcEKE11tom-tDXQ</Key>
-          <ComponentName>Stock/C81 Plasma Cannon</ComponentName>
+          <ComponentName>Stock/C54 Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>yN7f-9tEXEKlBNskqP6EbA</Key>
-          <ComponentName>Stock/T30 Cannon</ComponentName>
+          <ComponentName>Stock/T81 Plasma Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>Z2uDs34J-ESu64-i9YGnxQ</Key>
-          <ComponentName>Stock/T30 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>gb6_3kWBY0KlEWeex3ruDg</Key>
-          <ComponentName>Stock/P11 PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>_y-Bd-EWjUeMIrmzG3UxvQ</Key>
-          <ComponentName>Stock/P11 PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>gDQghm5iik2syYcoJqUPFg</Key>
-          <ComponentName>Stock/Reinforced CIC</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>vtme83CXg0qDA4_YK6NqwA</Key>
-          <ComponentName>Stock/Reinforced Magazine</ComponentName>
-          <ComponentData xsi:type="BulkMagazineData">
-            <Load>
-              <MagSaveData>
-                <MagazineKey>Dp5ZjV5lLEqjTnB6wHMcLw</MagazineKey>
-                <MunitionKey>Stock/100mm HE-HC Shell</MunitionKey>
-                <Quantity>1000</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>Pe7LL3LnL0S4fs8Y1UkKzQ</MagazineKey>
-                <MunitionKey>Stock/100mm HE Shell</MunitionKey>
-                <Quantity>300</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>WBJjVKPsEEqFkPRkNELmBA</MagazineKey>
-                <MunitionKey>Stock/100mm AP Shell</MunitionKey>
-                <Quantity>200</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>xaj-Lqnp-kG13_XRPdnokg</MagazineKey>
-                <MunitionKey>Stock/400mm Plasma Ampoule</MunitionKey>
-                <Quantity>100</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>hYLuSX3ugkmUlIW4ZN9SCw</MagazineKey>
-                <MunitionKey>Stock/20mm Slug</MunitionKey>
-                <Quantity>20000</Quantity>
-              </MagSaveData>
-            </Load>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>TTM8O-MUDky06__LwvSo8w</Key>
-          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>rGVFgJ8GyUePoRkz33c1sw</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>_hUvj899GkWP0bnjDN1ODw</Key>
-          <ComponentName>Stock/Berthing</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>N4KIOsNqeUGVAUrx5OW3DQ</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>9K_1ZNCgFESrvaoQMOH3yw</Key>
-          <ComponentName>Stock/Civilian Reactor</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>HNv6B-78FEuhV8YT9A6uZw</Key>
-          <ComponentName>Stock/CHI-777 Yard Drive</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>HvdEBsnpUUypPN4uW67paQ</Key>
-          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>iDdlfFwKkUO9HbumzymceA</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>DaqWEX-8gEeIzYrhp8NIMw</Key>
-          <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
-        </HullSocket>
-      </SocketMap>
-      <WeaponGroups>
-        <WepGroup Name="Gun">
-          <MemberKeys>
-            <string>yN7f-9tEXEKlBNskqP6EbA</string>
-            <string>Z2uDs34J-ESu64-i9YGnxQ</string>
-          </MemberKeys>
-        </WepGroup>
-        <WepGroup Name="Plas">
-          <MemberKeys>
-            <string>4V6twrIUcEKE11tom-tDXQ</string>
-          </MemberKeys>
-        </WepGroup>
-      </WeaponGroups>
-      <InitialFormation>
-        <GuideKey>e70ec13d-8565-4e92-b4fe-f0238b8d2d3a</GuideKey>
-        <RelativePosition>
-          <x>-0.0216760635</x>
-          <y>30.4568253</y>
-          <z>0.393280029</z>
-        </RelativePosition>
-      </InitialFormation>
-      <TemplateMissileTypes />
-    </Ship>
-    <Ship>
-      <SaveID xsi:nil="true" />
-      <Key>59ca8461-b50e-45e7-b50c-3b96dfcd62d9</Key>
-      <Name>Most Divine</Name>
-      <Cost>533</Cost>
-      <Callsign />
-      <Number>385</Number>
-      <SymbolOption>0</SymbolOption>
-      <HullType>Stock/Bulk Feeder</HullType>
-      <SocketMap>
-        <HullSocket>
-          <Key>4V6twrIUcEKE11tom-tDXQ</Key>
-          <ComponentName>Stock/C81 Plasma Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>yN7f-9tEXEKlBNskqP6EbA</Key>
-          <ComponentName>Stock/T30 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>Z2uDs34J-ESu64-i9YGnxQ</Key>
-          <ComponentName>Stock/T30 Cannon</ComponentName>
+          <ComponentName>Stock/T81 Plasma Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>gb6_3kWBY0KlEWeex3ruDg</Key>
@@ -421,44 +588,39 @@ A quartet of Plasma and T30 Monitors form the core of an easy to use all purpose
         </HullSocket>
         <HullSocket>
           <Key>vtme83CXg0qDA4_YK6NqwA</Key>
-          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentName>Stock/Citadel Magazine</ComponentName>
           <ComponentData xsi:type="BulkMagazineData">
             <Load>
               <MagSaveData>
-                <MagazineKey>Dp5ZjV5lLEqjTnB6wHMcLw</MagazineKey>
-                <MunitionKey>Stock/100mm HE-HC Shell</MunitionKey>
-                <Quantity>1000</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>Pe7LL3LnL0S4fs8Y1UkKzQ</MagazineKey>
-                <MunitionKey>Stock/100mm HE Shell</MunitionKey>
-                <Quantity>300</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>WBJjVKPsEEqFkPRkNELmBA</MagazineKey>
-                <MunitionKey>Stock/100mm AP Shell</MunitionKey>
+                <MagazineKey>KT0DgU0u-kKffMUQLio5_A</MagazineKey>
+                <MunitionKey>Stock/400mm Plasma Ampoule</MunitionKey>
                 <Quantity>200</Quantity>
               </MagSaveData>
               <MagSaveData>
-                <MagazineKey>xaj-Lqnp-kG13_XRPdnokg</MagazineKey>
-                <MunitionKey>Stock/400mm Plasma Ampoule</MunitionKey>
-                <Quantity>100</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>g4ovxVZJlUOYscgNumq1bQ</MagazineKey>
+                <MagazineKey>jJZVsNkjx0yVS-vBRKYgYQ</MagazineKey>
                 <MunitionKey>Stock/Flak Round</MunitionKey>
-                <Quantity>1000</Quantity>
+                <Quantity>450</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>gJmc9TEyX0egVzFgbABPPw</MagazineKey>
+                <MunitionKey>Stock/250mm AP Shell</MunitionKey>
+                <Quantity>150</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>w1uoDmjgV0-J1MiZYZVeCA</MagazineKey>
+                <MunitionKey>Stock/250mm HE Shell</MunitionKey>
+                <Quantity>150</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>TTM8O-MUDky06__LwvSo8w</Key>
-          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>rGVFgJ8GyUePoRkz33c1sw</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>_hUvj899GkWP0bnjDN1ODw</Key>
@@ -466,111 +628,111 @@ A quartet of Plasma and T30 Monitors form the core of an easy to use all purpose
         </HullSocket>
         <HullSocket>
           <Key>N4KIOsNqeUGVAUrx5OW3DQ</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <ComponentName>Stock/Damage Control Complex</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>9K_1ZNCgFESrvaoQMOH3yw</Key>
-          <ComponentName>Stock/Civilian Reactor</ComponentName>
+          <ComponentName>Stock/Boosted Reactor</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>HNv6B-78FEuhV8YT9A6uZw</Key>
-          <ComponentName>Stock/CHI-777 Yard Drive</ComponentName>
+          <ComponentName>Stock/BW800 Drive</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>HvdEBsnpUUypPN4uW67paQ</Key>
-          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
+          <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>iDdlfFwKkUO9HbumzymceA</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+          <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>DaqWEX-8gEeIzYrhp8NIMw</Key>
           <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
         </HullSocket>
+        <HullSocket>
+          <Key>EvZ6JN5xV0aUlKEeeKxFTQ</Key>
+          <ComponentName>Stock/Small Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>CU_oraqJxEaB3dTzZW2MkA</Key>
+          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
+        </HullSocket>
       </SocketMap>
       <WeaponGroups>
-        <WepGroup Name="Gun">
+        <WepGroup Name="Plasma">
           <MemberKeys>
             <string>yN7f-9tEXEKlBNskqP6EbA</string>
             <string>Z2uDs34J-ESu64-i9YGnxQ</string>
           </MemberKeys>
         </WepGroup>
-        <WepGroup Name="Plas">
+        <WepGroup Name="250">
           <MemberKeys>
             <string>4V6twrIUcEKE11tom-tDXQ</string>
           </MemberKeys>
         </WepGroup>
       </WeaponGroups>
       <InitialFormation>
-        <GuideKey>e70ec13d-8565-4e92-b4fe-f0238b8d2d3a</GuideKey>
+        <GuideKey>224e5998-56d0-4c78-9859-5e7f1d7a1473</GuideKey>
         <RelativePosition>
-          <x>23.9060516</x>
-          <y>-18.0570221</y>
-          <z>-1.10798645</z>
+          <x>-0.342633247</x>
+          <y>-30.0376358</y>
+          <z>0.268951416</z>
         </RelativePosition>
       </InitialFormation>
       <TemplateMissileTypes />
     </Ship>
     <Ship>
       <SaveID xsi:nil="true" />
-      <Key>9b2f3e87-9e4a-48ab-8d62-1be45a4c1d63</Key>
+      <Key>fa6e7c43-a004-4b59-94c9-5baa60f3ede6</Key>
       <Name>Somewhere Out There</Name>
-      <Cost>361</Cost>
+      <Cost>218</Cost>
       <Callsign />
-      <Number>511</Number>
+      <Number>70</Number>
       <SymbolOption>0</SymbolOption>
       <HullType>Stock/Tugboat</HullType>
       <SocketMap>
         <HullSocket>
           <Key>03vxralGq0CFx1XKxjOcBA</Key>
-          <ComponentName>Stock/P20 Flak PDT</ComponentName>
+          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
+            <MissileLoad>
+              <MagSaveData>
+                <MagazineKey>tNTc0zonsEKQdn3tQrLQxw</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-112 Parry</MunitionKey>
+                <Quantity>14</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>t90eTwY_KEyr4sA6UCcK7Q</MagazineKey>
+                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
+                <Quantity>4</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>GfEqgSwXSkqkqSGSKsdCqQ</MagazineKey>
+                <MunitionKey>Stock/EA20 Flare Decoy</MunitionKey>
+                <Quantity>1</Quantity>
+              </MagSaveData>
+            </MissileLoad>
+          </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>cIGspM4oYU2etRfjIcuCCA</Key>
           <ComponentName>Stock/R550 Early Warning Radar</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>0upOgm0H0UuZ-h2YvRjmBg</Key>
-          <ComponentName>Stock/P20 Flak PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>KnFHQkb9uUe98IweLYf9wg</Key>
-          <ComponentName>Stock/P11 PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>5kd20hGcxUuTlY-6JYaudA</Key>
-          <ComponentName>Stock/P11 PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
           <Key>F6bmJdCO3EqzXK9SBJoXUw</Key>
-          <ComponentName>Stock/Reinforced CIC</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>-PqoLKimSUOZtKMLo5QHXg</Key>
-          <ComponentName>Stock/Reinforced Magazine</ComponentName>
-          <ComponentData xsi:type="BulkMagazineData">
-            <Load>
-              <MagSaveData>
-                <MagazineKey>hnuQDHAnJ0u9nEwD-qLfxw</MagazineKey>
-                <MunitionKey>Stock/Flak Round</MunitionKey>
-                <Quantity>800</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>ns1CpFs1d0GGc-MLHw713A</MagazineKey>
-                <MunitionKey>Stock/20mm Slug</MunitionKey>
-                <Quantity>10000</Quantity>
-              </MagSaveData>
-            </Load>
-          </ComponentData>
+          <ComponentName>Stock/Basic CIC</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>DakKS2gy6UyM58u3YG-HfQ</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load />
+          </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>peqaYrE39UupWCXPY_PgoA</Key>
-          <ComponentName>Stock/Small DC Locker</ComponentName>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>6OieSH0A6kKFmquctn9_aQ</Key>
@@ -583,14 +745,6 @@ A quartet of Plasma and T30 Monitors form the core of an easy to use all purpose
         <HullSocket>
           <Key>_qlP8rsUpUiJpkRc1tcjPQ</Key>
           <ComponentName>Stock/BW800 Drive</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>RMDTRlITGUm1ZgbIgWq1Xw</Key>
-          <ComponentName>Stock/Adaptive Radar Receiver</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>v7vnexI1xUemaSmSkn0QNA</Key>
-          <ComponentName>Stock/Adaptive Radar Receiver</ComponentName>
         </HullSocket>
       </SocketMap>
       <WeaponGroups>
@@ -600,107 +754,6 @@ A quartet of Plasma and T30 Monitors form the core of an easy to use all purpose
           </MemberKeys>
         </WepGroup>
       </WeaponGroups>
-      <TemplateMissileTypes />
-    </Ship>
-    <Ship>
-      <SaveID xsi:nil="true" />
-      <Key>8f7ea023-cf60-4a00-9cfa-9b0cc9cd0f91</Key>
-      <Name>Somewhere In Here</Name>
-      <Cost>428</Cost>
-      <Callsign />
-      <Number>914</Number>
-      <SymbolOption>0</SymbolOption>
-      <HullType>Stock/Tugboat</HullType>
-      <SocketMap>
-        <HullSocket>
-          <Key>03vxralGq0CFx1XKxjOcBA</Key>
-          <ComponentName>Stock/R400 Radar</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>cIGspM4oYU2etRfjIcuCCA</Key>
-          <ComponentName>Stock/L50 Laser Dazzler</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>0upOgm0H0UuZ-h2YvRjmBg</Key>
-          <ComponentName>Stock/VLS-1-46 Launcher</ComponentName>
-          <ComponentData xsi:type="CellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>tOZtENVwek6OYlREzjapdw</MagazineKey>
-                <MunitionKey>$MODMIS$/SGM-112 Parry</MunitionKey>
-                <Quantity>20</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>Oy18c-bahEyE4Q4S1x5K1w</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>8</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>KnFHQkb9uUe98IweLYf9wg</Key>
-          <ComponentName>Stock/P60 Laser PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>5kd20hGcxUuTlY-6JYaudA</Key>
-          <ComponentName>Stock/P60 Laser PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>F6bmJdCO3EqzXK9SBJoXUw</Key>
-          <ComponentName>Stock/Reinforced CIC</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>-PqoLKimSUOZtKMLo5QHXg</Key>
-          <ComponentName>Stock/Reinforced Magazine</ComponentName>
-          <ComponentData xsi:type="BulkMagazineData">
-            <Load />
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>DakKS2gy6UyM58u3YG-HfQ</Key>
-          <ComponentName>Stock/Small DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>peqaYrE39UupWCXPY_PgoA</Key>
-          <ComponentName>Stock/Plant Control Center</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>6OieSH0A6kKFmquctn9_aQ</Key>
-          <ComponentName>Stock/Berthing</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>NSAbhn9brE-aAirJFIYG-Q</Key>
-          <ComponentName>Stock/Boosted Reactor</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>_qlP8rsUpUiJpkRc1tcjPQ</Key>
-          <ComponentName>Stock/BW800 Drive</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>RMDTRlITGUm1ZgbIgWq1Xw</Key>
-          <ComponentName>Stock/Track Correlator</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>v7vnexI1xUemaSmSkn0QNA</Key>
-          <ComponentName>Stock/Track Correlator</ComponentName>
-        </HullSocket>
-      </SocketMap>
-      <WeaponGroups>
-        <WepGroup Name="Dazlr">
-          <MemberKeys>
-            <string>cIGspM4oYU2etRfjIcuCCA</string>
-          </MemberKeys>
-        </WepGroup>
-      </WeaponGroups>
-      <InitialFormation>
-        <GuideKey>9b2f3e87-9e4a-48ab-8d62-1be45a4c1d63</GuideKey>
-        <RelativePosition>
-          <x>30.3136063</x>
-          <y>0</y>
-          <z>-0.289703369</z>
-        </RelativePosition>
-      </InitialFormation>
       <TemplateMissileTypes />
     </Ship>
   </Ships>
@@ -716,12 +769,12 @@ Targeting Modes:
 	&lt;b&gt;&lt;color=#4CFF72&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
 Primary Seeker: ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
 
-300 m/s for 4,715 m, top speed in 0.6 s
+250 m/s for 2,520 m, top speed in 0.4 s
 Terminal Maneuvers: None
 
 Proximity Fuze, High Explosive, Blast Fragmentation
-Armor: 1cm   Component: 48hp
-Blast Radius: 40 m
+Armor: 2cm   Component: 65hp
+Blast Radius: 47 m
 
 Body Integrity: 10 
 Programming Time: 6 s
@@ -760,32 +813,33 @@ Failure Rate: 0 %</LongDescription>
           <InstalledComponent xsi:type="DirectGuidanceSettings">
             <ComponentKey>Stock/Direct Guidance</ComponentKey>
             <Role>Defensive</Role>
-            <HotLaunch>false</HotLaunch>
+            <HotLaunch>true</HotLaunch>
             <SelfDestructOnLost>false</SelfDestructOnLost>
             <Maneuvers>None</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>Hybrid</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
-              <SalvoSize>0</SalvoSize>
+              <SalvoSize>1</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
             </DefensiveDoctrine>
             <ApproachAngleControl>true</ApproachAngleControl>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>3</Size>
+          <Size>4</Size>
           <InstalledComponent>
             <ComponentKey>Stock/Blast Fragmentation</ComponentKey>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>4</Size>
+          <Size>3</Size>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.335913241</A>
-              <B>0.3336519</B>
-              <C>0.330434859</C>
+              <A>0</A>
+              <B>0.2372433</B>
+              <C>0.7627567</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>

--- a/data/fleets/Kyanite Squadron.fleet
+++ b/data/fleets/Kyanite Squadron.fleet
@@ -4,15 +4,16 @@
   <Version>3</Version>
   <TotalPoints>3000</TotalPoints>
   <FactionKey>Stock/Protectorate</FactionKey>
-  <Description>Difficulty: &lt;color=yellow&gt;MODERATE&lt;/color&gt;
+  <Description>Difficulty: &lt;color=green&gt;EASY&lt;/color&gt;
 
-Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy casemate guns on one side and missile launchers on the other. It is a simple, tanky fleet perfect for engaging at mid-long ranges with evasive maneuvers and by popping in and out of cover. Heading and roll management will be critical to employ the big guns of these two ships in conjunction with the directional long range tracking radar. While vulnerable to being flanked, Kyanite Squadron has a moderate point defense net and anti-missile complement on its cannon side.</Description>
+Kyanite Squadron is comprised of dual lineships with heavy guns on one side and missile launchers on the other. It is a simple, semi-durable fleet perfect for engaging at mid-long ranges by popping in and out of cover to dump bursts of fire. Use of the hold heading command will be critical to pre-align the fleet's big guns and tracking radar. While vulnerable to being flanked, the fleet has a significant point defense net and interceptor missile complement. The fleet's offensive missiles are suited for finishing off damaged warships or dealing with small scouts.</Description>
+  <SortOverrideOrder>2</SortOverrideOrder>
   <Ships>
     <Ship>
       <SaveID xsi:nil="true" />
       <Key>0ad9e563-d7aa-4326-be4a-faa822cf5e49</Key>
       <Name>No Other Way</Name>
-      <Cost>1503</Cost>
+      <Cost>1482</Cost>
       <Callsign />
       <Number>344</Number>
       <SymbolOption>0</SymbolOption>
@@ -90,7 +91,7 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
         </HullSocket>
         <HullSocket>
           <Key>bxvsvg5znk6TqiIKq8H0kg</Key>
-          <ComponentName>Stock/P60 Laser PDT</ComponentName>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>9EF9u0V1eUetleBnkQhHkA</Key>
@@ -106,9 +107,9 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
           <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>XtEk6ydzqUuGCaTBI88Bzw</MagazineKey>
-                <MunitionKey>$MODMIS$/SGM-100 Riposte II Block V</MunitionKey>
-                <Quantity>31</Quantity>
+                <MagazineKey>E_N7G4kg_U-2bVOZxp4KgQ</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-1 Mk.9 Counter</MunitionKey>
+                <Quantity>33</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
@@ -131,7 +132,7 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
         </HullSocket>
         <HullSocket>
           <Key>3Ky8PvdxqUKMRXZa0xLF2A</Key>
-          <ComponentName>Stock/Large DC Storage</ComponentName>
+          <ComponentName>Stock/Damage Control Complex</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>fYoX2amTl0KrZurPKjU9gg</Key>
@@ -141,54 +142,54 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
               <MagSaveData>
                 <MagazineKey>fhDzeisGD0K0uBG7fPcPIg</MagazineKey>
                 <MunitionKey>Stock/450mm AP Shell</MunitionKey>
-                <Quantity>275</Quantity>
+                <Quantity>350</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>cV3HgXPCPUuz7ACwRThpzw</MagazineKey>
                 <MunitionKey>Stock/450mm HE Shell</MunitionKey>
-                <Quantity>600</Quantity>
+                <Quantity>325</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>praYgX873kK5QSu95E4iMg</MagazineKey>
                 <MunitionKey>Stock/Flak Round</MunitionKey>
-                <Quantity>825</Quantity>
+                <Quantity>875</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>4B3q_OHi5U-r5OFuGd_DlQ</MagazineKey>
                 <MunitionKey>Stock/20mm Slug</MunitionKey>
-                <Quantity>20000</Quantity>
+                <Quantity>8000</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>CEyahSEfxUO8ZbpB2MzDmw</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-289 Type 14</MunitionKey>
-                <Quantity>34</Quantity>
+                <Quantity>24</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>T9TN0ZYumUaCxcSRjO_qTw</Key>
-          <ComponentName>Stock/Gun Plotting Center</ComponentName>
+          <ComponentName>Stock/Plant Control Center</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>T4d-8WnA_UiHSJh6PXiXpA</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>6LpDL27QuEW0PZCm35Nx5w</Key>
           <ComponentName>Stock/Gun Plotting Center</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>QIOFQpQSKESIdNzf_JEFyA</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>FVcPIcV_00eu62NQQK3oLg</Key>
+          <Key>6LpDL27QuEW0PZCm35Nx5w</Key>
           <ComponentName>Stock/Reinforced CIC</ComponentName>
         </HullSocket>
         <HullSocket>
+          <Key>QIOFQpQSKESIdNzf_JEFyA</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>FVcPIcV_00eu62NQQK3oLg</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
           <Key>1FrTJ5o850ynlq4dRDmMbA</Key>
-          <ComponentName>Stock/Damage Control Central</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>vOzzHo4KfE60wZ3Q1s38GA</Key>
@@ -200,7 +201,7 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
         </HullSocket>
         <HullSocket>
           <Key>JVCLf3RKKUOBEXaWWkVLMw</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+          <ComponentName>Stock/Light Civilian Reactor</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>JHJi2y5Xskytpw5-Qbu95A</Key>
@@ -216,11 +217,11 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
         </HullSocket>
         <HullSocket>
           <Key>S-rQo19r20K0L0PRer3yMw</Key>
-          <ComponentName>Stock/Light Civilian Reactor</ComponentName>
+          <ComponentName>Stock/Track Correlator</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>M3mc7A4WOU-2fq5XgRSECA</Key>
-          <ComponentName>Stock/Light Civilian Reactor</ComponentName>
+          <ComponentName>Stock/Track Correlator</ComponentName>
         </HullSocket>
       </SocketMap>
       <WeaponGroups>
@@ -244,7 +245,7 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
       <SaveID xsi:nil="true" />
       <Key>47fba6f0-c961-457a-a19d-1373288733b1</Key>
       <Name>Final Orders</Name>
-      <Cost>1497</Cost>
+      <Cost>1518</Cost>
       <Callsign />
       <Number>366</Number>
       <SymbolOption>0</SymbolOption>
@@ -298,15 +299,15 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
           <ComponentName>Stock/C65 Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
+          <Key>auQ7ijGeX0evdikZQeBxTg</Key>
+          <ComponentName>Stock/MLS-2 Launcher</ComponentName>
+        </HullSocket>
+        <HullSocket>
           <Key>d3N-B_JnDUKAdVRBJ6nvFQ</Key>
           <ComponentName>Stock/C65 Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>xvNT1_DYcUuSpU6rrmL_4A</Key>
-          <ComponentName>Stock/MLS-2 Launcher</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>t0T4CSAPnEq4rvHAVl84-Q</Key>
           <ComponentName>Stock/MLS-2 Launcher</ComponentName>
         </HullSocket>
         <HullSocket>
@@ -335,16 +336,16 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
           <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>uE75x1kwiUi6NK8-lr7MgA</MagazineKey>
-                <MunitionKey>$MODMIS$/SGM-100 Riposte II Block V</MunitionKey>
-                <Quantity>31</Quantity>
+                <MagazineKey>J7C-7z3TmUGl3WwkycZiDw</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-1 Mk.9 Counter</MunitionKey>
+                <Quantity>33</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>6ZiODnoXqkaNWvaqyGjnwg</Key>
-          <ComponentName>Stock/P11 PDT</ComponentName>
+          <ComponentName>Stock/P20 Flak PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>87PSgg9GREmGU9MIRAXXhg</Key>
@@ -352,7 +353,7 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
         </HullSocket>
         <HullSocket>
           <Key>VDQhZPo-rkWkzwozat27fw</Key>
-          <ComponentName>Stock/P20 Flak PDT</ComponentName>
+          <ComponentName>Stock/P11 PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>y1Cs8LR0KUyCKUAJBIOyOg</Key>
@@ -366,34 +367,34 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
               <MagSaveData>
                 <MagazineKey>fhDzeisGD0K0uBG7fPcPIg</MagazineKey>
                 <MunitionKey>Stock/450mm AP Shell</MunitionKey>
-                <Quantity>275</Quantity>
+                <Quantity>500</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>cV3HgXPCPUuz7ACwRThpzw</MagazineKey>
                 <MunitionKey>Stock/450mm HE Shell</MunitionKey>
-                <Quantity>600</Quantity>
+                <Quantity>450</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>praYgX873kK5QSu95E4iMg</MagazineKey>
                 <MunitionKey>Stock/Flak Round</MunitionKey>
-                <Quantity>750</Quantity>
+                <Quantity>875</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>4B3q_OHi5U-r5OFuGd_DlQ</MagazineKey>
                 <MunitionKey>Stock/20mm Slug</MunitionKey>
-                <Quantity>20000</Quantity>
+                <Quantity>8000</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>CEyahSEfxUO8ZbpB2MzDmw</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-289 Type 14</MunitionKey>
-                <Quantity>34</Quantity>
+                <Quantity>24</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>3Ky8PvdxqUKMRXZa0xLF2A</Key>
-          <ComponentName>Stock/Large DC Storage</ComponentName>
+          <ComponentName>Stock/Damage Control Complex</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>T9TN0ZYumUaCxcSRjO_qTw</Key>
@@ -401,15 +402,15 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
         </HullSocket>
         <HullSocket>
           <Key>T4d-8WnA_UiHSJh6PXiXpA</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>6LpDL27QuEW0PZCm35Nx5w</Key>
-          <ComponentName>Stock/Gun Plotting Center</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>QIOFQpQSKESIdNzf_JEFyA</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>FVcPIcV_00eu62NQQK3oLg</Key>
@@ -417,7 +418,7 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
         </HullSocket>
         <HullSocket>
           <Key>1FrTJ5o850ynlq4dRDmMbA</Key>
-          <ComponentName>Stock/Damage Control Central</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>vOzzHo4KfE60wZ3Q1s38GA</Key>
@@ -447,6 +448,10 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
           <Key>S-rQo19r20K0L0PRer3yMw</Key>
           <ComponentName>Stock/Light Civilian Reactor</ComponentName>
         </HullSocket>
+        <HullSocket>
+          <Key>M3mc7A4WOU-2fq5XgRSECA</Key>
+          <ComponentName>Stock/Light Civilian Reactor</ComponentName>
+        </HullSocket>
       </SocketMap>
       <WeaponGroups>
         <WepGroup Name="Gun">
@@ -459,11 +464,19 @@ Kyanite Squadron comprises of twin Bulk Freighter class Line ships with heavy ca
         </WepGroup>
         <WepGroup Name="MLS">
           <MemberKeys>
+            <string>auQ7ijGeX0evdikZQeBxTg</string>
             <string>xvNT1_DYcUuSpU6rrmL_4A</string>
-            <string>t0T4CSAPnEq4rvHAVl84-Q</string>
           </MemberKeys>
         </WepGroup>
       </WeaponGroups>
+      <InitialFormation>
+        <GuideKey>0ad9e563-d7aa-4326-be4a-faa822cf5e49</GuideKey>
+        <RelativePosition>
+          <x>-0.09498596</x>
+          <y>0</y>
+          <z>-60.15754</z>
+        </RelativePosition>
+      </InitialFormation>
       <TemplateMissileTypes />
     </Ship>
   </Ships>
@@ -480,12 +493,13 @@ Targeting Modes:
 Primary Seeker: ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
 Validation Seeker(s): COMMAND (&lt;color=#FBFF4C&gt;Requires COMMS Enabled&lt;/color&gt;)
 
-294 m/s for 9,052 m, top speed in 1.8 s
+251 m/s for 9,002 m, top speed in 1.5 s
 Terminal Maneuvers: Weave
 
 Contact Fuze, High Explosive, Shaped
-Armor: 60cm   Component: 1,200hp
+Armor: 66cm   Component: 1,440hp
 Blast Angle: 70 deg
+Damage Per Fragment: 50.0
 
 Body Integrity: 30 
 Programming Time: 8 s
@@ -496,7 +510,7 @@ Boost-Phase Turn Rate: 100 %
 Failure Rate: 0 %</LongDescription>
       <Cost>10</Cost>
       <BodyKey>Stock/SGM-2 Body</BodyKey>
-      <TemplateKey>ebd7901e-b38e-4f16-acfc-b781b539b3ca</TemplateKey>
+      <TemplateKey>ddf56f14-7f14-4e5c-8c61-cf0a5d1ccd80</TemplateKey>
       <BaseColor>
         <r>0.178571567</r>
         <g>0.9999999</g>
@@ -515,7 +529,7 @@ Failure Rate: 0 %</LongDescription>
           <InstalledComponent xsi:type="ActiveSeekerSettings">
             <ComponentKey>Stock/Steerable Active Radar Seeker</ComponentKey>
             <Mode>Targeting</Mode>
-            <RejectUnvalidated>true</RejectUnvalidated>
+            <RejectUnvalidated>false</RejectUnvalidated>
             <DetectPDTargets>false</DetectPDTargets>
           </InstalledComponent>
         </MissileSocket>
@@ -537,6 +551,7 @@ Failure Rate: 0 %</LongDescription>
             <Maneuvers>Weave</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
@@ -545,41 +560,41 @@ Failure Rate: 0 %</LongDescription>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>5</Size>
+          <Size>6</Size>
           <InstalledComponent>
             <ComponentKey>Stock/HE Impact</ComponentKey>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>5</Size>
+          <Size>4</Size>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.7177391</A>
-              <B>0.146790564</B>
-              <C>0.135470331</C>
+              <A>0.504627</A>
+              <B>0.322223365</B>
+              <C>0.173149645</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>
       </Sockets>
     </MissileTemplate>
     <MissileTemplate>
-      <Designation>SGM-100</Designation>
-      <Nickname>Riposte II Block V</Nickname>
+      <Designation>SGM-1</Designation>
+      <Nickname>Mk.9 Counter</Nickname>
       <Description>DIRECT - ACT(&lt;color=#4CFF72&gt;RADAR&lt;/color&gt;) - HE FRAG</Description>
-      <LongDescription>The SGM-100 Riposte II Block V is a size 1 direct guidance missile.  It is based on the SGM-1 body, which is a nimble general-purpose missile.  This missile will deliver a Proximity Fuze, High Explosive, Blast Fragmentation warhead.  It homes in on its target using an Active Radar seeker.
+      <LongDescription>The SGM-1 Mk.9 Counter is a size 1 direct guidance missile.  It is based on the SGM-1 body, which is a nimble general-purpose missile.  This missile will deliver a Proximity Fuze, High Explosive, Blast Fragmentation warhead.  It homes in on its target using an Active Radar seeker.
 
 Control Method: DIRECT
 Targeting Modes:
 	&lt;b&gt;&lt;color=#4CFF72&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
 Primary Seeker: ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
 
-346 m/s for 5,022 m, top speed in 0.9 s
+250 m/s for 2,958 m, top speed in 0.3 s
 Terminal Maneuvers: None
 
 Proximity Fuze, High Explosive, Blast Fragmentation
-Armor: 1cm   Component: 48hp
-Blast Radius: 40 m
+Armor: 2cm   Component: 33hp
+Blast Radius: 30 m
 
 Body Integrity: 10 
 Programming Time: 6 s
@@ -588,19 +603,19 @@ Boost-Phase Duration: 3 s
 Boost-Phase Strafe: 100 %
 Boost-Phase Turn Rate: 100 %
 Failure Rate: 0 %</LongDescription>
-      <Cost>2</Cost>
+      <Cost>3</Cost>
       <BodyKey>Stock/SGM-1 Body</BodyKey>
-      <TemplateKey>d24af149-d834-49b6-af1b-d84c776d4676</TemplateKey>
+      <TemplateKey>d96855e6-7b43-4162-8281-650450d4a1dd</TemplateKey>
       <BaseColor>
-        <r>0.092857115</r>
-        <g>0.9999999</g>
+        <r>0.9999999</r>
+        <g>0.7874478</g>
         <b>0</b>
         <a>1</a>
       </BaseColor>
       <StripeColor>
-        <r>0.254901975</r>
-        <g>0.254901975</g>
-        <b>0.254901975</b>
+        <r>0.7475385</r>
+        <g>0</g>
+        <b>0.9999999</b>
         <a>1</a>
       </StripeColor>
       <Sockets>
@@ -623,27 +638,28 @@ Failure Rate: 0 %</LongDescription>
             <Maneuvers>None</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>Hybrid</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
-              <SalvoSize>0</SalvoSize>
-              <FarthestFirst>false</FarthestFirst>
+              <SalvoSize>1</SalvoSize>
+              <FarthestFirst>true</FarthestFirst>
             </DefensiveDoctrine>
             <ApproachAngleControl>true</ApproachAngleControl>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>3</Size>
+          <Size>1</Size>
           <InstalledComponent>
-            <ComponentKey>Stock/Blast Fragmentation</ComponentKey>
+            <ComponentKey>Stock/Blast Fragmentation EL</ComponentKey>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>4</Size>
+          <Size>6</Size>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.6416276</A>
-              <B>0.2901872</B>
-              <C>0.06818518</C>
+              <A>0</A>
+              <B>-0</B>
+              <C>1</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>

--- a/data/fleets/TF Ash.fleet
+++ b/data/fleets/TF Ash.fleet
@@ -6,7 +6,7 @@
   <FactionKey>Stock/Alliance</FactionKey>
   <Description>Difficulty: &lt;color=red&gt;HARD&lt;/color&gt;
 
-A close range beam brawling fleet.  Consists of three destroyers and an ECM/Scout corvette.  You'll need to get in extremely close to make use of the destroyers' beams, but they can also deliver a punch from a distance with their missile complement.</Description>
+A close range beam brawling fleet. Consists of three beam destroyers and an ECM corvette. You'll need to get in close to make use of the destroyers' beams, but they can also deliver a punch from a distance with their missile complement. Use of jamming and/or careful ambush planning is absolutely crucial to get the destroyers to firing range.</Description>
   <SortOverrideOrder>6</SortOverrideOrder>
   <Ships>
     <Ship>
@@ -108,19 +108,15 @@ A close range beam brawling fleet.  Consists of three destroyers and an ECM/Scou
         </HullSocket>
         <HullSocket>
           <Key>fSYv4j5-eEObwJEVhoBSvg</Key>
-          <ComponentName>Stock/CLS-3 Launcher</ComponentName>
-          <ComponentData xsi:type="ResizableCellLauncherData">
+          <ComponentName>Stock/Torpedo Turret</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>5hEvp4yrXkqe7FiiLYMw-Q</MagazineKey>
+                <MagazineKey>ms1oFCCuwUu2ltlfjdpdlg</MagazineKey>
                 <MunitionKey>$MODMIS$/SGT-300 Hail</MunitionKey>
                 <Quantity>6</Quantity>
               </MagSaveData>
             </MissileLoad>
-            <ConfiguredSize>
-              <x>1</x>
-              <y>3</y>
-            </ConfiguredSize>
           </ComponentData>
         </HullSocket>
         <HullSocket>
@@ -139,7 +135,7 @@ A close range beam brawling fleet.  Consists of three destroyers and an ECM/Scou
               <MagSaveData>
                 <MagazineKey>y1y33bb31E-ua9RV0CGafw</MagazineKey>
                 <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>12</Quantity>
+                <Quantity>6</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>4znP_s3JUkCk5z_8QcFMKQ</MagazineKey>
@@ -149,7 +145,7 @@ A close range beam brawling fleet.  Consists of three destroyers and an ECM/Scou
               <MagSaveData>
                 <MagazineKey>U__yY1f26E6F4ReTizMpLw</MagazineKey>
                 <MunitionKey>Stock/EA99 Active Decoy</MunitionKey>
-                <Quantity>2</Quantity>
+                <Quantity>1</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
@@ -285,19 +281,15 @@ A close range beam brawling fleet.  Consists of three destroyers and an ECM/Scou
         </HullSocket>
         <HullSocket>
           <Key>fSYv4j5-eEObwJEVhoBSvg</Key>
-          <ComponentName>Stock/CLS-3 Launcher</ComponentName>
-          <ComponentData xsi:type="ResizableCellLauncherData">
+          <ComponentName>Stock/Torpedo Turret</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>5hEvp4yrXkqe7FiiLYMw-Q</MagazineKey>
+                <MagazineKey>CybmMvV2tkyii7jqIJFMWw</MagazineKey>
                 <MunitionKey>$MODMIS$/SGT-300 Hail</MunitionKey>
                 <Quantity>6</Quantity>
               </MagSaveData>
             </MissileLoad>
-            <ConfiguredSize>
-              <x>1</x>
-              <y>3</y>
-            </ConfiguredSize>
           </ComponentData>
         </HullSocket>
         <HullSocket>
@@ -316,7 +308,7 @@ A close range beam brawling fleet.  Consists of three destroyers and an ECM/Scou
               <MagSaveData>
                 <MagazineKey>y1y33bb31E-ua9RV0CGafw</MagazineKey>
                 <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>12</Quantity>
+                <Quantity>6</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>4znP_s3JUkCk5z_8QcFMKQ</MagazineKey>
@@ -326,7 +318,7 @@ A close range beam brawling fleet.  Consists of three destroyers and an ECM/Scou
               <MagSaveData>
                 <MagazineKey>U__yY1f26E6F4ReTizMpLw</MagazineKey>
                 <MunitionKey>Stock/EA99 Active Decoy</MunitionKey>
-                <Quantity>2</Quantity>
+                <Quantity>1</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
@@ -462,19 +454,15 @@ A close range beam brawling fleet.  Consists of three destroyers and an ECM/Scou
         </HullSocket>
         <HullSocket>
           <Key>fSYv4j5-eEObwJEVhoBSvg</Key>
-          <ComponentName>Stock/CLS-3 Launcher</ComponentName>
-          <ComponentData xsi:type="ResizableCellLauncherData">
+          <ComponentName>Stock/Torpedo Turret</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>5hEvp4yrXkqe7FiiLYMw-Q</MagazineKey>
+                <MagazineKey>XcQxYLq1Bk6n7xI291W6yQ</MagazineKey>
                 <MunitionKey>$MODMIS$/SGT-300 Hail</MunitionKey>
                 <Quantity>6</Quantity>
               </MagSaveData>
             </MissileLoad>
-            <ConfiguredSize>
-              <x>1</x>
-              <y>3</y>
-            </ConfiguredSize>
           </ComponentData>
         </HullSocket>
         <HullSocket>
@@ -493,7 +481,7 @@ A close range beam brawling fleet.  Consists of three destroyers and an ECM/Scou
               <MagSaveData>
                 <MagazineKey>y1y33bb31E-ua9RV0CGafw</MagazineKey>
                 <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>11</Quantity>
+                <Quantity>5</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>4znP_s3JUkCk5z_8QcFMKQ</MagazineKey>
@@ -503,7 +491,7 @@ A close range beam brawling fleet.  Consists of three destroyers and an ECM/Scou
               <MagSaveData>
                 <MagazineKey>U__yY1f26E6F4ReTizMpLw</MagazineKey>
                 <MunitionKey>Stock/EA99 Active Decoy</MunitionKey>
-                <Quantity>2</Quantity>
+                <Quantity>1</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
@@ -630,6 +618,7 @@ Terminal Maneuvers: None
 Contact Fuze, High Explosive, Shaped
 Armor: 54cm   Component: 960hp
 Blast Angle: 70 deg
+Damage Per Fragment: 50.0
 
 Body Integrity: 30 
 Programming Time: 8 s
@@ -676,6 +665,7 @@ Failure Rate: 0 %</LongDescription>
             <Maneuvers>None</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
@@ -713,21 +703,22 @@ Targeting Modes:
 	&lt;b&gt;&lt;color=#FF2525&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
 Primary Seeker: COMMAND (&lt;color=#FBFF4C&gt;Requires COMMS Enabled&lt;/color&gt;)
 
-178 m/s for 6,104 m, top speed in 1.7 s
+264 m/s for 2,563 m, top speed in 1.6 s
 Terminal Maneuvers: None
 
 Contact Fuze, High Explosive, Shaped
 Armor: 123cm   Component: 5,040hp
 Blast Angle: 70 deg
+Damage Per Fragment: 50.0
 
-Body Integrity: 110 
-Programming Time: 6 s
+Body Integrity: 160 
+Programming Time: 3 s
 Radar Signature Bonus: 100 %
 Boost-Phase Duration: 3 s
 Boost-Phase Strafe: 250 % (&lt;color=#4CFF72&gt;+150%&lt;/color&gt;)
 Boost-Phase Turn Rate: 200 % (&lt;color=#4CFF72&gt;+100%&lt;/color&gt;)
 Failure Rate: 0 %</LongDescription>
-      <Cost>11</Cost>
+      <Cost>12</Cost>
       <BodyKey>Stock/SGT-3 Body</BodyKey>
       <TemplateKey>3ccf279c-9f6f-4f45-ae95-87aebf36b729</TemplateKey>
       <BaseColor>
@@ -767,6 +758,7 @@ Failure Rate: 0 %</LongDescription>
             <Maneuvers>None</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>

--- a/data/fleets/TF Birch.fleet
+++ b/data/fleets/TF Birch.fleet
@@ -6,378 +6,16 @@
   <FactionKey>Stock/Alliance</FactionKey>
   <Description>Difficulty: &lt;color=green&gt;EASY&lt;/color&gt;
 
-Three light cruisers which excel at hunting down and destroying support ships like corvette and frigates.  When used to support a team they are excellent for poking out the enemy's eyes and leaving their own heavy-hitters exposed for you to mop up.</Description>
+Triple light cruisers with medium cannons and electronic warfare. This fleet excels at hunting down scouts and escorts, but its weapons can struggle against armoured opponents. Use superior mobility and jammers to pick fights you can win and escape from fights that you can't, but beware of ambushes. Light cruisers can be easily dismantled if caught up close where they can't evade incoming fire.</Description>
   <SortOverrideOrder>2</SortOverrideOrder>
   <Ships>
     <Ship>
       <SaveID xsi:nil="true" />
-      <Key>26b0dde7-4845-49a5-b282-9f25a14ffa20</Key>
-      <Name>Ruby of Adi</Name>
-      <Cost>995</Cost>
-      <Callsign />
-      <Number>141</Number>
-      <SymbolOption>0</SymbolOption>
-      <HullType>Stock/Vauxhall Light Cruiser</HullType>
-      <SocketMap>
-        <HullSocket>
-          <Key>T9Ebo41iA0eBXNYx8uyisw</Key>
-          <ComponentName>Stock/RF101 'Bullseye' Radar</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>2QQdxC4UE0KOM42r82-ETQ</Key>
-          <ComponentName>Stock/Mk64 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>IFKM9E04aUaHS0IoNDMShA</Key>
-          <ComponentName>Stock/Mk64 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>rX6hes7UqkyHjEyKbFaWTQ</Key>
-          <ComponentName>Stock/Mk64 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>BRMwuusKC02YrbFXRrrNzA</Key>
-          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>vO1oPhlSuUih_cdAZk3Hqg</Key>
-          <ComponentName>Stock/Mk64 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>RLHQUFf200uLZjKX5axkMw</Key>
-          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>uyPDg0tD3U6YKz18bVdkPg</Key>
-          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>Xicf0TT7pEaFy_x1uk7ueQ</Key>
-          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
-          <ComponentData xsi:type="CellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>QNN0ov8f_0SzJJcxmw2esg</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>19</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>XTg1H1Popku5gxW8sei5XQ</Key>
-          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
-          <ComponentData xsi:type="CellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>p-iSmsfqN0mzcMLxPaDLqA</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>19</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>a8H-rPyVSk6uBOrP7lQYUA</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>NBbnpHfpDUSS6bNgDlSjzw</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>f_SO68qAGU-sw69T9GEWow</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>9R0tfjsN-kiETUBLeCCmGw</Key>
-          <ComponentName>Stock/Reinforced CIC</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>-bAF6R6aiU2Afn8T_oKY4g</Key>
-          <ComponentName>Stock/Gun Plotting Center</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>-7H3WGDwyESDI3lkHzBdGQ</Key>
-          <ComponentName>Stock/Plant Control Center</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>o1o5WOogUE255YVi43KlcQ</Key>
-          <ComponentName>Stock/Berthing</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>DAcDeA0yskSjje92CY-F7w</Key>
-          <ComponentName>Stock/Berthing</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>jKvCg9nYmkKfAn4-ht_Y6A</Key>
-          <ComponentName>Stock/Reinforced Magazine</ComponentName>
-          <ComponentData xsi:type="BulkMagazineData">
-            <Load>
-              <MagSaveData>
-                <MagazineKey>-f09k0cANU-1q-iBazQ8uQ</MagazineKey>
-                <MunitionKey>Stock/250mm HE Shell</MunitionKey>
-                <Quantity>700</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>CYStXEBOc0evZ5NmEGGQXg</MagazineKey>
-                <MunitionKey>Stock/250mm AP Shell</MunitionKey>
-                <Quantity>300</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>ZBtRcOGI2EaeLk99EzprnQ</MagazineKey>
-                <MunitionKey>Stock/250mm HE-RPF Shell</MunitionKey>
-                <Quantity>200</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>XdGaSjzkfE2BIc3mGTjcHA</MagazineKey>
-                <MunitionKey>Stock/20mm Slug</MunitionKey>
-                <Quantity>7500</Quantity>
-              </MagSaveData>
-            </Load>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>8VKMmbA23Em1f-MBZKO2vA</Key>
-          <ComponentName>Stock/FR4800 Reactor</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>udQjNCWlA0awkv6LhH55uQ</Key>
-          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>3eXWUksWXk-5q9MW52rghw</Key>
-          <ComponentName>Stock/FM500 Drive</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>_jqFwgf3EkKUUqHzVWidzw</Key>
-          <ComponentName>Stock/Mount Gyros</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>qulLVFUtzk2Qm8rZtfpFDw</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>N_gGUWCQx0mUOX9RaFoI6A</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>E1ZSbpYpZkufCyifYiiK8Q</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>-hETYcmKH0eeXzkFpnhgeg</Key>
-          <ComponentName>Stock/RS35 'Frontline' Radar</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>hU2L93VfQU-jutnRC0dKgw</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
-        </HullSocket>
-      </SocketMap>
-      <WeaponGroups>
-        <WepGroup Name="Top gun">
-          <MemberKeys>
-            <string>IFKM9E04aUaHS0IoNDMShA</string>
-            <string>rX6hes7UqkyHjEyKbFaWTQ</string>
-          </MemberKeys>
-        </WepGroup>
-        <WepGroup Name="Bottom gun">
-          <MemberKeys>
-            <string>2QQdxC4UE0KOM42r82-ETQ</string>
-            <string>vO1oPhlSuUih_cdAZk3Hqg</string>
-          </MemberKeys>
-        </WepGroup>
-      </WeaponGroups>
-      <TemplateMissileTypes />
-    </Ship>
-    <Ship>
-      <SaveID xsi:nil="true" />
-      <Key>adc596be-d421-4ffa-b9be-9f7954ff5d75</Key>
-      <Name>Wild Air</Name>
-      <Cost>995</Cost>
-      <Callsign />
-      <Number>611</Number>
-      <SymbolOption>0</SymbolOption>
-      <HullType>Stock/Vauxhall Light Cruiser</HullType>
-      <SocketMap>
-        <HullSocket>
-          <Key>T9Ebo41iA0eBXNYx8uyisw</Key>
-          <ComponentName>Stock/RF101 'Bullseye' Radar</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>2QQdxC4UE0KOM42r82-ETQ</Key>
-          <ComponentName>Stock/Mk64 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>IFKM9E04aUaHS0IoNDMShA</Key>
-          <ComponentName>Stock/Mk64 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>rX6hes7UqkyHjEyKbFaWTQ</Key>
-          <ComponentName>Stock/Mk64 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>BRMwuusKC02YrbFXRrrNzA</Key>
-          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>vO1oPhlSuUih_cdAZk3Hqg</Key>
-          <ComponentName>Stock/Mk64 Cannon</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>RLHQUFf200uLZjKX5axkMw</Key>
-          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>uyPDg0tD3U6YKz18bVdkPg</Key>
-          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>Xicf0TT7pEaFy_x1uk7ueQ</Key>
-          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
-          <ComponentData xsi:type="CellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>QNN0ov8f_0SzJJcxmw2esg</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>19</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>XTg1H1Popku5gxW8sei5XQ</Key>
-          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
-          <ComponentData xsi:type="CellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>p-iSmsfqN0mzcMLxPaDLqA</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>19</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>a8H-rPyVSk6uBOrP7lQYUA</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>NBbnpHfpDUSS6bNgDlSjzw</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>f_SO68qAGU-sw69T9GEWow</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>9R0tfjsN-kiETUBLeCCmGw</Key>
-          <ComponentName>Stock/Reinforced CIC</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>-bAF6R6aiU2Afn8T_oKY4g</Key>
-          <ComponentName>Stock/Gun Plotting Center</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>-7H3WGDwyESDI3lkHzBdGQ</Key>
-          <ComponentName>Stock/Plant Control Center</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>o1o5WOogUE255YVi43KlcQ</Key>
-          <ComponentName>Stock/Berthing</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>DAcDeA0yskSjje92CY-F7w</Key>
-          <ComponentName>Stock/Berthing</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>jKvCg9nYmkKfAn4-ht_Y6A</Key>
-          <ComponentName>Stock/Reinforced Magazine</ComponentName>
-          <ComponentData xsi:type="BulkMagazineData">
-            <Load>
-              <MagSaveData>
-                <MagazineKey>-f09k0cANU-1q-iBazQ8uQ</MagazineKey>
-                <MunitionKey>Stock/250mm HE Shell</MunitionKey>
-                <Quantity>700</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>CYStXEBOc0evZ5NmEGGQXg</MagazineKey>
-                <MunitionKey>Stock/250mm AP Shell</MunitionKey>
-                <Quantity>300</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>ZBtRcOGI2EaeLk99EzprnQ</MagazineKey>
-                <MunitionKey>Stock/250mm HE-RPF Shell</MunitionKey>
-                <Quantity>200</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>XdGaSjzkfE2BIc3mGTjcHA</MagazineKey>
-                <MunitionKey>Stock/20mm Slug</MunitionKey>
-                <Quantity>7500</Quantity>
-              </MagSaveData>
-            </Load>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>8VKMmbA23Em1f-MBZKO2vA</Key>
-          <ComponentName>Stock/FR4800 Reactor</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>udQjNCWlA0awkv6LhH55uQ</Key>
-          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>3eXWUksWXk-5q9MW52rghw</Key>
-          <ComponentName>Stock/FM500 Drive</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>_jqFwgf3EkKUUqHzVWidzw</Key>
-          <ComponentName>Stock/Mount Gyros</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>qulLVFUtzk2Qm8rZtfpFDw</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>N_gGUWCQx0mUOX9RaFoI6A</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>E1ZSbpYpZkufCyifYiiK8Q</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>-hETYcmKH0eeXzkFpnhgeg</Key>
-          <ComponentName>Stock/RS35 'Frontline' Radar</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>hU2L93VfQU-jutnRC0dKgw</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
-        </HullSocket>
-      </SocketMap>
-      <WeaponGroups>
-        <WepGroup Name="Top gun">
-          <MemberKeys>
-            <string>IFKM9E04aUaHS0IoNDMShA</string>
-            <string>rX6hes7UqkyHjEyKbFaWTQ</string>
-          </MemberKeys>
-        </WepGroup>
-        <WepGroup Name="Bottom gun">
-          <MemberKeys>
-            <string>2QQdxC4UE0KOM42r82-ETQ</string>
-            <string>vO1oPhlSuUih_cdAZk3Hqg</string>
-          </MemberKeys>
-        </WepGroup>
-      </WeaponGroups>
-      <TemplateMissileTypes />
-    </Ship>
-    <Ship>
-      <SaveID xsi:nil="true" />
       <Key>75c4adc0-7093-4fd7-af94-dcee5adc2687</Key>
-      <Name>Arced Peace</Name>
-      <Cost>1010</Cost>
+      <Name>Mark The Time</Name>
+      <Cost>992</Cost>
       <Callsign />
-      <Number>1064</Number>
+      <Number>140</Number>
       <SymbolOption>0</SymbolOption>
       <HullType>Stock/Vauxhall Light Cruiser</HullType>
       <SocketMap>
@@ -399,7 +37,16 @@ Three light cruisers which excel at hunting down and destroying support ships li
         </HullSocket>
         <HullSocket>
           <Key>BRMwuusKC02YrbFXRrrNzA</Key>
-          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
+          <ComponentName>Stock/VLS-1-46 Launcher</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
+            <MissileLoad>
+              <MagSaveData>
+                <MagazineKey>xui-ZCNOCEqqmPIKSO4X9g</MagazineKey>
+                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
+                <Quantity>13</Quantity>
+              </MagSaveData>
+            </MissileLoad>
+          </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>vO1oPhlSuUih_cdAZk3Hqg</Key>
@@ -415,41 +62,23 @@ Three light cruisers which excel at hunting down and destroying support ships li
         </HullSocket>
         <HullSocket>
           <Key>Xicf0TT7pEaFy_x1uk7ueQ</Key>
-          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
-          <ComponentData xsi:type="CellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>QNN0ov8f_0SzJJcxmw2esg</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>19</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-          </ComponentData>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>XTg1H1Popku5gxW8sei5XQ</Key>
-          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
-          <ComponentData xsi:type="CellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>p-iSmsfqN0mzcMLxPaDLqA</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>19</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-          </ComponentData>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>a8H-rPyVSk6uBOrP7lQYUA</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>NBbnpHfpDUSS6bNgDlSjzw</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>f_SO68qAGU-sw69T9GEWow</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <ComponentName>Stock/Berthing</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>9R0tfjsN-kiETUBLeCCmGw</Key>
@@ -457,19 +86,15 @@ Three light cruisers which excel at hunting down and destroying support ships li
         </HullSocket>
         <HullSocket>
           <Key>-bAF6R6aiU2Afn8T_oKY4g</Key>
-          <ComponentName>Stock/Gun Plotting Center</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>-7H3WGDwyESDI3lkHzBdGQ</Key>
-          <ComponentName>Stock/Plant Control Center</ComponentName>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>o1o5WOogUE255YVi43KlcQ</Key>
-          <ComponentName>Stock/Berthing</ComponentName>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>DAcDeA0yskSjje92CY-F7w</Key>
-          <ComponentName>Stock/Berthing</ComponentName>
+          <ComponentName>Stock/Large DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>jKvCg9nYmkKfAn4-ht_Y6A</Key>
@@ -477,31 +102,31 @@ Three light cruisers which excel at hunting down and destroying support ships li
           <ComponentData xsi:type="BulkMagazineData">
             <Load>
               <MagSaveData>
-                <MagazineKey>-f09k0cANU-1q-iBazQ8uQ</MagazineKey>
-                <MunitionKey>Stock/250mm HE Shell</MunitionKey>
-                <Quantity>700</Quantity>
-              </MagSaveData>
-              <MagSaveData>
                 <MagazineKey>CYStXEBOc0evZ5NmEGGQXg</MagazineKey>
                 <MunitionKey>Stock/250mm AP Shell</MunitionKey>
-                <Quantity>300</Quantity>
+                <Quantity>550</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>-f09k0cANU-1q-iBazQ8uQ</MagazineKey>
+                <MunitionKey>Stock/250mm HE Shell</MunitionKey>
+                <Quantity>550</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>ZBtRcOGI2EaeLk99EzprnQ</MagazineKey>
                 <MunitionKey>Stock/250mm HE-RPF Shell</MunitionKey>
-                <Quantity>200</Quantity>
+                <Quantity>550</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>XdGaSjzkfE2BIc3mGTjcHA</MagazineKey>
                 <MunitionKey>Stock/20mm Slug</MunitionKey>
-                <Quantity>7500</Quantity>
+                <Quantity>12000</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>8VKMmbA23Em1f-MBZKO2vA</Key>
-          <ComponentName>Stock/FR4800 Reactor</ComponentName>
+          <ComponentName>Stock/FM230 'Whiplash' Drive</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>udQjNCWlA0awkv6LhH55uQ</Key>
@@ -509,11 +134,11 @@ Three light cruisers which excel at hunting down and destroying support ships li
         </HullSocket>
         <HullSocket>
           <Key>3eXWUksWXk-5q9MW52rghw</Key>
-          <ComponentName>Stock/FM500 Drive</ComponentName>
+          <ComponentName>Stock/FM580 'Raider' Drive</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>_jqFwgf3EkKUUqHzVWidzw</Key>
-          <ComponentName>Stock/Mount Gyros</ComponentName>
+          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>qulLVFUtzk2Qm8rZtfpFDw</Key>
@@ -521,7 +146,7 @@ Three light cruisers which excel at hunting down and destroying support ships li
         </HullSocket>
         <HullSocket>
           <Key>N_gGUWCQx0mUOX9RaFoI6A</Key>
-          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>E1ZSbpYpZkufCyifYiiK8Q</Key>
@@ -537,19 +162,343 @@ Three light cruisers which excel at hunting down and destroying support ships li
         </HullSocket>
       </SocketMap>
       <WeaponGroups>
-        <WepGroup Name="Top gun">
-          <MemberKeys>
-            <string>IFKM9E04aUaHS0IoNDMShA</string>
-            <string>rX6hes7UqkyHjEyKbFaWTQ</string>
-          </MemberKeys>
-        </WepGroup>
-        <WepGroup Name="Bottom gun">
+        <WepGroup Name="Main Guns">
           <MemberKeys>
             <string>2QQdxC4UE0KOM42r82-ETQ</string>
+            <string>IFKM9E04aUaHS0IoNDMShA</string>
+            <string>rX6hes7UqkyHjEyKbFaWTQ</string>
             <string>vO1oPhlSuUih_cdAZk3Hqg</string>
           </MemberKeys>
         </WepGroup>
       </WeaponGroups>
+      <TemplateMissileTypes />
+    </Ship>
+    <Ship>
+      <SaveID xsi:nil="true" />
+      <Key>26b0dde7-4845-49a5-b282-9f25a14ffa20</Key>
+      <Name>Exit Criteria Met</Name>
+      <Cost>1004</Cost>
+      <Callsign />
+      <Number>141</Number>
+      <SymbolOption>0</SymbolOption>
+      <HullType>Stock/Vauxhall Light Cruiser</HullType>
+      <SocketMap>
+        <HullSocket>
+          <Key>T9Ebo41iA0eBXNYx8uyisw</Key>
+          <ComponentName>Stock/E90 'Blanket' Jammer</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>2QQdxC4UE0KOM42r82-ETQ</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>IFKM9E04aUaHS0IoNDMShA</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>rX6hes7UqkyHjEyKbFaWTQ</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>vO1oPhlSuUih_cdAZk3Hqg</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>RLHQUFf200uLZjKX5axkMw</Key>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>uyPDg0tD3U6YKz18bVdkPg</Key>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>Xicf0TT7pEaFy_x1uk7ueQ</Key>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>XTg1H1Popku5gxW8sei5XQ</Key>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>a8H-rPyVSk6uBOrP7lQYUA</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>NBbnpHfpDUSS6bNgDlSjzw</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>f_SO68qAGU-sw69T9GEWow</Key>
+          <ComponentName>Stock/Berthing</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>9R0tfjsN-kiETUBLeCCmGw</Key>
+          <ComponentName>Stock/Reinforced CIC</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>-bAF6R6aiU2Afn8T_oKY4g</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>o1o5WOogUE255YVi43KlcQ</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>DAcDeA0yskSjje92CY-F7w</Key>
+          <ComponentName>Stock/Large DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>jKvCg9nYmkKfAn4-ht_Y6A</Key>
+          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>CYStXEBOc0evZ5NmEGGQXg</MagazineKey>
+                <MunitionKey>Stock/250mm AP Shell</MunitionKey>
+                <Quantity>550</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>-f09k0cANU-1q-iBazQ8uQ</MagazineKey>
+                <MunitionKey>Stock/250mm HE Shell</MunitionKey>
+                <Quantity>550</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>ZBtRcOGI2EaeLk99EzprnQ</MagazineKey>
+                <MunitionKey>Stock/250mm HE-RPF Shell</MunitionKey>
+                <Quantity>550</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>XdGaSjzkfE2BIc3mGTjcHA</MagazineKey>
+                <MunitionKey>Stock/20mm Slug</MunitionKey>
+                <Quantity>12000</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>8VKMmbA23Em1f-MBZKO2vA</Key>
+          <ComponentName>Stock/FM230 'Whiplash' Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>udQjNCWlA0awkv6LhH55uQ</Key>
+          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>3eXWUksWXk-5q9MW52rghw</Key>
+          <ComponentName>Stock/FM580 'Raider' Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_jqFwgf3EkKUUqHzVWidzw</Key>
+          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>qulLVFUtzk2Qm8rZtfpFDw</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>N_gGUWCQx0mUOX9RaFoI6A</Key>
+          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>E1ZSbpYpZkufCyifYiiK8Q</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>-hETYcmKH0eeXzkFpnhgeg</Key>
+          <ComponentName>Stock/RM50 'Parallax' Radar</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>hU2L93VfQU-jutnRC0dKgw</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+      </SocketMap>
+      <WeaponGroups>
+        <WepGroup Name="Main Guns">
+          <MemberKeys>
+            <string>2QQdxC4UE0KOM42r82-ETQ</string>
+            <string>IFKM9E04aUaHS0IoNDMShA</string>
+            <string>rX6hes7UqkyHjEyKbFaWTQ</string>
+            <string>vO1oPhlSuUih_cdAZk3Hqg</string>
+          </MemberKeys>
+        </WepGroup>
+        <WepGroup Name="Jammers">
+          <MemberKeys>
+            <string>T9Ebo41iA0eBXNYx8uyisw</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
+      <InitialFormation>
+        <GuideKey>75c4adc0-7093-4fd7-af94-dcee5adc2687</GuideKey>
+        <RelativePosition>
+          <x>-29.9858685</x>
+          <y>0</y>
+          <z>-0.0815887451</z>
+        </RelativePosition>
+      </InitialFormation>
+      <TemplateMissileTypes />
+    </Ship>
+    <Ship>
+      <SaveID xsi:nil="true" />
+      <Key>adc596be-d421-4ffa-b9be-9f7954ff5d75</Key>
+      <Name>The Proven Factor</Name>
+      <Cost>1004</Cost>
+      <Callsign />
+      <Number>142</Number>
+      <SymbolOption>0</SymbolOption>
+      <HullType>Stock/Vauxhall Light Cruiser</HullType>
+      <SocketMap>
+        <HullSocket>
+          <Key>T9Ebo41iA0eBXNYx8uyisw</Key>
+          <ComponentName>Stock/E90 'Blanket' Jammer</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>2QQdxC4UE0KOM42r82-ETQ</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>IFKM9E04aUaHS0IoNDMShA</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>rX6hes7UqkyHjEyKbFaWTQ</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>vO1oPhlSuUih_cdAZk3Hqg</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>RLHQUFf200uLZjKX5axkMw</Key>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>uyPDg0tD3U6YKz18bVdkPg</Key>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>Xicf0TT7pEaFy_x1uk7ueQ</Key>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>XTg1H1Popku5gxW8sei5XQ</Key>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>a8H-rPyVSk6uBOrP7lQYUA</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>NBbnpHfpDUSS6bNgDlSjzw</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>f_SO68qAGU-sw69T9GEWow</Key>
+          <ComponentName>Stock/Berthing</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>9R0tfjsN-kiETUBLeCCmGw</Key>
+          <ComponentName>Stock/Reinforced CIC</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>-bAF6R6aiU2Afn8T_oKY4g</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>o1o5WOogUE255YVi43KlcQ</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>DAcDeA0yskSjje92CY-F7w</Key>
+          <ComponentName>Stock/Large DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>jKvCg9nYmkKfAn4-ht_Y6A</Key>
+          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>CYStXEBOc0evZ5NmEGGQXg</MagazineKey>
+                <MunitionKey>Stock/250mm AP Shell</MunitionKey>
+                <Quantity>550</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>-f09k0cANU-1q-iBazQ8uQ</MagazineKey>
+                <MunitionKey>Stock/250mm HE Shell</MunitionKey>
+                <Quantity>550</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>ZBtRcOGI2EaeLk99EzprnQ</MagazineKey>
+                <MunitionKey>Stock/250mm HE-RPF Shell</MunitionKey>
+                <Quantity>550</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>XdGaSjzkfE2BIc3mGTjcHA</MagazineKey>
+                <MunitionKey>Stock/20mm Slug</MunitionKey>
+                <Quantity>12000</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>8VKMmbA23Em1f-MBZKO2vA</Key>
+          <ComponentName>Stock/FM230 'Whiplash' Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>udQjNCWlA0awkv6LhH55uQ</Key>
+          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>3eXWUksWXk-5q9MW52rghw</Key>
+          <ComponentName>Stock/FM580 'Raider' Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_jqFwgf3EkKUUqHzVWidzw</Key>
+          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>qulLVFUtzk2Qm8rZtfpFDw</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>N_gGUWCQx0mUOX9RaFoI6A</Key>
+          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>E1ZSbpYpZkufCyifYiiK8Q</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>-hETYcmKH0eeXzkFpnhgeg</Key>
+          <ComponentName>Stock/RM50 'Parallax' Radar</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>hU2L93VfQU-jutnRC0dKgw</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+      </SocketMap>
+      <WeaponGroups>
+        <WepGroup Name="Main Guns">
+          <MemberKeys>
+            <string>2QQdxC4UE0KOM42r82-ETQ</string>
+            <string>IFKM9E04aUaHS0IoNDMShA</string>
+            <string>rX6hes7UqkyHjEyKbFaWTQ</string>
+            <string>vO1oPhlSuUih_cdAZk3Hqg</string>
+          </MemberKeys>
+        </WepGroup>
+        <WepGroup Name="Jammers">
+          <MemberKeys>
+            <string>T9Ebo41iA0eBXNYx8uyisw</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
+      <InitialFormation>
+        <GuideKey>75c4adc0-7093-4fd7-af94-dcee5adc2687</GuideKey>
+        <RelativePosition>
+          <x>30.0192738</x>
+          <y>0</y>
+          <z>-0.118125916</z>
+        </RelativePosition>
+      </InitialFormation>
       <TemplateMissileTypes />
     </Ship>
   </Ships>

--- a/data/fleets/TF Hemlock.fleet
+++ b/data/fleets/TF Hemlock.fleet
@@ -6,14 +6,14 @@
   <FactionKey>Stock/Alliance</FactionKey>
   <Description>Difficulty: &lt;color=yellow&gt;MODERATE&lt;/color&gt;
 
-A close range and extremely capable cannon/beam heavy cruiser, which also carries a set of 16 deadly hybrid missiles on its rearmost primary mount.  It's flanked by two support and scout corvettes to extend its reach.  With a wide variety of weapons, this group can comfortably engage many different types of threats, but beward of specialized enemies.</Description>
+A close range and extremely capable cannon/beam heavy cruiser, which also carries a set of 16 deadly hybrid missiles on its rearmost primary mount. It's flanked by two jamming corvettes to act as escorts and sacrifices if need be. With a wide variety of weapons, this group can comfortably engage many different types of threats, but beware of engaging specialized enemies in their domains.</Description>
   <SortOverrideOrder>3</SortOverrideOrder>
   <Ships>
     <Ship>
       <SaveID xsi:nil="true" />
       <Key>895097d9-935c-47f1-85fc-21567b59c84b</Key>
       <Name>Totem</Name>
-      <Cost>2352</Cost>
+      <Cost>2194</Cost>
       <Callsign />
       <Number>886</Number>
       <SymbolOption>0</SymbolOption>
@@ -29,9 +29,9 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
           <ComponentData xsi:type="ResizableCellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>EAKuVQ8hpUCN0VdhOAsKFg</MagazineKey>
+                <MagazineKey>y1XjELL1i0iAbe4HgglyZA</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-H-303 Javelin</MunitionKey>
-                <Quantity>16</Quantity>
+                <Quantity>12</Quantity>
               </MagSaveData>
             </MissileLoad>
             <ConfiguredSize>
@@ -50,7 +50,7 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
         </HullSocket>
         <HullSocket>
           <Key>9qreGP2Iw0KwuloNpNFTSg</Key>
-          <ComponentName>Stock/Mk29 'Stonewall' PDT</ComponentName>
+          <ComponentName>Stock/Mk95 'Sarissa' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>v9Sqa5DcCkibdi29AkakNg</Key>
@@ -58,7 +58,7 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
         </HullSocket>
         <HullSocket>
           <Key>3MoeYUx1HUS6xNDBMsssig</Key>
-          <ComponentName>Stock/Mk29 'Stonewall' PDT</ComponentName>
+          <ComponentName>Stock/Mk95 'Sarissa' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>LbD9Txe-S0a_nODTqtrk7g</Key>
@@ -66,15 +66,15 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
         </HullSocket>
         <HullSocket>
           <Key>KxV0hkkGBE2AOUCo5axQbg</Key>
-          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>tyGXrucCjUe0FVyP1YDpUw</Key>
-          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>rXZhdtbK3EC8K_cu6-r_Xg</Key>
-          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>ylUvmASKlEiyCtyCsNRKWg</Key>
@@ -93,17 +93,27 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
               <MagSaveData>
                 <MagazineKey>fY2PiuDapE-GA7keA5a9KA</MagazineKey>
                 <MunitionKey>Stock/250mm HE Shell</MunitionKey>
-                <Quantity>300</Quantity>
+                <Quantity>500</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>-9nYVKWbQEOa6wQ7oSkabQ</MagazineKey>
                 <MunitionKey>Stock/250mm AP Shell</MunitionKey>
-                <Quantity>300</Quantity>
+                <Quantity>500</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>v9MTf8eDrE-b-mm1V8jFnw</MagazineKey>
                 <MunitionKey>Stock/250mm HE-RPF Shell</MunitionKey>
-                <Quantity>250</Quantity>
+                <Quantity>350</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>y3Rw-bd5b0qennOZV0pVlA</MagazineKey>
+                <MunitionKey>Stock/20mm Slug</MunitionKey>
+                <Quantity>16000</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>UY8mm9D_uEitNiNWbfdElw</MagazineKey>
+                <MunitionKey>Stock/15mm Sandshot</MunitionKey>
+                <Quantity>200</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
@@ -130,11 +140,11 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
         </HullSocket>
         <HullSocket>
           <Key>2xmOS4ns_EaMYjBXrrhhig</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>y1xLixKUzUSKT7Nz7aUkLQ</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <ComponentName>Stock/Reinforced CIC</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>RmUeePb-8EGbFaRgVjCXsA</Key>
@@ -154,11 +164,11 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
         </HullSocket>
         <HullSocket>
           <Key>2ZLEJvxYf0CATl1lBi3cuQ</Key>
-          <ComponentName>Stock/FM580 'Raider' Drive</ComponentName>
+          <ComponentName>Stock/FM540 'Dragonfly' Drive</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>ba-3VQ-zGEmDCfU12uaqaA</Key>
-          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
+          <ComponentName>Stock/Focused Particle Accelerator</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>hQ-Mzyns0UO4oMp7gG0d8A</Key>
@@ -178,7 +188,7 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
         </HullSocket>
         <HullSocket>
           <Key>awwdeDnNs0G-RceQF1TByA</Key>
-          <ComponentName>Stock/Mount Gyros</ComponentName>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>tnZD-B5Ls0qAyBtdz4yoTA</Key>
@@ -186,7 +196,7 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
         </HullSocket>
         <HullSocket>
           <Key>S8ALcpOMYEqJog1v2q8UMQ</Key>
-          <ComponentName>Stock/RM50 'Parallax' Radar</ComponentName>
+          <ComponentName>Stock/RS41 'Spyglass' Radar</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>rQWETsDGdE-AR8N3NPfwXg</Key>
@@ -200,7 +210,7 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
       <SaveID xsi:nil="true" />
       <Key>ba2f3f90-b114-4f6d-8b7e-9d50570309d2</Key>
       <Name>Coastline</Name>
-      <Cost>337</Cost>
+      <Cost>403</Cost>
       <Callsign />
       <Number>899</Number>
       <SymbolOption>0</SymbolOption>
@@ -216,24 +226,9 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
           <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>k89QjBtMs0apHnCy9enREQ</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>11</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>-3X_mBgto0-eZiu7D3t6gw</MagazineKey>
-                <MunitionKey>Stock/EA20 Flare Decoy</MunitionKey>
-                <Quantity>11</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>vyOXJNvMVE-dd001M1XgSw</MagazineKey>
-                <MunitionKey>Stock/EA99 Active Decoy</MunitionKey>
-                <Quantity>5</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>Da9VqlYBdkC61IlOFWhxKg</MagazineKey>
+                <MagazineKey>eKj-WngLtUaV_mNwzpmmQQ</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-121 Saber</MunitionKey>
-                <Quantity>13</Quantity>
+                <Quantity>32</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
@@ -244,6 +239,10 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
         </HullSocket>
         <HullSocket>
           <Key>xRYIkvssd0mPY3VIgrnQ5A</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>GefqwCQzg0qXA3EFRmDtPw</Key>
           <ComponentName>Stock/Berthing</ComponentName>
         </HullSocket>
         <HullSocket>
@@ -267,9 +266,9 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
       <InitialFormation>
         <GuideKey>895097d9-935c-47f1-85fc-21567b59c84b</GuideKey>
         <RelativePosition>
-          <x>30.0137863</x>
+          <x>30.1853828</x>
           <y>0</y>
-          <z>-26.4596977</z>
+          <z>-26.2173519</z>
         </RelativePosition>
       </InitialFormation>
       <TemplateMissileTypes />
@@ -278,7 +277,7 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
       <SaveID xsi:nil="true" />
       <Key>51e76824-11a4-4dcf-9836-70de737daa86</Key>
       <Name>Chief's Eye</Name>
-      <Cost>311</Cost>
+      <Cost>403</Cost>
       <Callsign />
       <Number>6413</Number>
       <SymbolOption>0</SymbolOption>
@@ -286,7 +285,7 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
       <SocketMap>
         <HullSocket>
           <Key>wDsRnL5nKkyYvKgD6VcPHg</Key>
-          <ComponentName>Stock/RF101 'Bullseye' Radar</ComponentName>
+          <ComponentName>Stock/E90 'Blanket' Jammer</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>Z48ot_dQfkWb6AVYjaM_gA</Key>
@@ -294,24 +293,9 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
           <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>ur2-dMq0_0OkbIOJP1-h3Q</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>11</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>danyybEHx0W9tvRfx2eaRQ</MagazineKey>
-                <MunitionKey>Stock/EA20 Flare Decoy</MunitionKey>
-                <Quantity>10</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>J8MGyACpX0CzKoBFkav6Yw</MagazineKey>
-                <MunitionKey>Stock/EA99 Active Decoy</MunitionKey>
-                <Quantity>5</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>q6bl7st-KEKRAsLVNwuPKg</MagazineKey>
+                <MagazineKey>_Ks5PEsV4UaUCtGu4Dgz5Q</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-121 Saber</MunitionKey>
-                <Quantity>12</Quantity>
+                <Quantity>32</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
@@ -322,6 +306,10 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
         </HullSocket>
         <HullSocket>
           <Key>xRYIkvssd0mPY3VIgrnQ5A</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>rXO8xwG1MkqzI_2pU-O_qQ</Key>
           <ComponentName>Stock/Berthing</ComponentName>
         </HullSocket>
         <HullSocket>
@@ -330,20 +318,24 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
         </HullSocket>
         <HullSocket>
           <Key>4EHx4mQhNUi-WuuQtQF5fA</Key>
-          <ComponentName>Stock/FM200R Drive</ComponentName>
+          <ComponentName>Stock/FM230 'Whiplash' Drive</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>TSPPW9ECe06-MGzR1i0WvQ</Key>
           <ComponentName>Stock/RS35 'Frontline' Radar</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>MBOvGazj6UWpt2OOy44s7w</Key>
+          <ComponentName>Stock/Small Reactor Booster</ComponentName>
         </HullSocket>
       </SocketMap>
       <WeaponGroups />
       <InitialFormation>
         <GuideKey>895097d9-935c-47f1-85fc-21567b59c84b</GuideKey>
         <RelativePosition>
-          <x>-32.411232</x>
+          <x>-32.57182</x>
           <y>0</y>
-          <z>-23.4055977</z>
+          <z>-23.1450214</z>
         </RelativePosition>
       </InitialFormation>
       <TemplateMissileTypes />
@@ -353,23 +345,24 @@ A close range and extremely capable cannon/beam heavy cruiser, which also carrie
     <MissileTemplate>
       <Designation>SGM-H-303</Designation>
       <Nickname>Javelin</Nickname>
-      <Description>DIRECT - &lt;color=#FBFF4C&gt;CMD&lt;/color&gt;/ARAD(&lt;color=#4CFF72&gt;RADAR&lt;/color&gt;) - HE SHAPED</Description>
-      <LongDescription>The SGM-H-303 Javelin is a size 3 direct guidance missile.  It is based on the SGM-H-3 body, which is a high speed hybrid missile designed to strike heavy targets.  This missile will deliver a Contact Fuze, High Explosive, Shaped warhead.  It homes in on its target using command guidance from its launching ship  If the primary seeker does not find a target or is jammed, it can fall back on a Radar Anti-Radiation seeker.
+      <Description>DIRECT - PSV(&lt;color=#53FFFF&gt;EO&lt;/color&gt;)/ACT(&lt;color=#4CFF72&gt;RADAR&lt;/color&gt;) - HE SHAPED</Description>
+      <LongDescription>The SGM-H-303 Javelin is a size 3 direct guidance missile.  It is based on the SGM-H-3 body, which is a high speed hybrid missile designed to strike heavy targets.  This missile will deliver a Contact Fuze, High Explosive, Shaped warhead.  It homes in on its target using a Passive Electro-Optical seeker  If the primary seeker does not find a target or is jammed, it can fall back on an Active Radar seeker.
 
 Control Method: DIRECT
 Targeting Modes:
 	&lt;b&gt;&lt;color=#4CFF72&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
-Primary Seeker: COMMAND (&lt;color=#FBFF4C&gt;Requires COMMS Enabled&lt;/color&gt;)
-Backup Seeker(s): ANTI-RADIATION (All &lt;color=#4CFF72&gt;RADAR&lt;/color&gt; Signals)
+Primary Seeker: PASSIVE (&lt;color=#53FFFF&gt;EO&lt;/color&gt;)
+Backup Seeker(s): ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
 
-Cruise: 185 m/s for 14,556 m, top speed in 2.9 s
-Sprint: 699 m/s for 4,881 m, top speed in 0.9 s
-   Stage Trigger at 4,000m from Target (&lt;color=#FBFF4C&gt;Limited By Seeker Range&lt;/color&gt;)
+Cruise: 200 m/s for 15,667 m, top speed in 3.3 s
+Sprint: 550 m/s for 5,848 m, top speed in 0.7 s
+   Stage Trigger at 4,780m from Target
 Terminal Maneuvers: Corkscrew
 
 Contact Fuze, High Explosive, Shaped
 Armor: 88cm   Component: 2,592hp
 Blast Angle: 70 deg
+Damage Per Fragment: 50.0
 
 Body Integrity: 60 
 Programming Time: 16 s
@@ -378,7 +371,7 @@ Boost-Phase Duration: 3 s
 Boost-Phase Strafe: 100 %
 Boost-Phase Turn Rate: 100 %
 Failure Rate: 0 %</LongDescription>
-      <Cost>34</Cost>
+      <Cost>37</Cost>
       <BodyKey>Stock/SGM-H-3 Body</BodyKey>
       <TemplateKey>05348c08-9352-42b0-b69a-64d5268221bd</TemplateKey>
       <BaseColor>
@@ -396,19 +389,20 @@ Failure Rate: 0 %</LongDescription>
       <Sockets>
         <MissileSocket>
           <Size>1</Size>
-          <InstalledComponent xsi:type="CommandSeekerSettings">
-            <ComponentKey>Stock/Command Receiver</ComponentKey>
+          <InstalledComponent xsi:type="PassiveSeekerSettings">
+            <ComponentKey>Stock/Electro-Optical Seeker</ComponentKey>
             <Mode>Targeting</Mode>
             <RejectUnvalidated>false</RejectUnvalidated>
+            <DetectPDTargets>false</DetectPDTargets>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
           <Size>1</Size>
-          <InstalledComponent xsi:type="PassiveARHSeekerSettings">
-            <ComponentKey>Stock/Fixed Anti-Radiation Seeker</ComponentKey>
+          <InstalledComponent xsi:type="ActiveSeekerSettings">
+            <ComponentKey>Stock/Steerable Extended Active Radar Seeker</ComponentKey>
             <Mode>Targeting</Mode>
             <RejectUnvalidated>false</RejectUnvalidated>
-            <TargetType>All</TargetType>
+            <DetectPDTargets>false</DetectPDTargets>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
@@ -427,6 +421,7 @@ Failure Rate: 0 %</LongDescription>
             <Maneuvers>Corkscrew</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
@@ -445,9 +440,9 @@ Failure Rate: 0 %</LongDescription>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.332107663</A>
-              <B>0.526991546</B>
-              <C>0.140900791</C>
+              <A>0</A>
+              <B>1</B>
+              <C>0</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>
@@ -456,9 +451,9 @@ Failure Rate: 0 %</LongDescription>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.8528157</A>
+              <A>1</A>
               <B>0</B>
-              <C>0.147184312</C>
+              <C>0</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>
@@ -467,20 +462,20 @@ Failure Rate: 0 %</LongDescription>
     <MissileTemplate>
       <Designation>SGM-121</Designation>
       <Nickname>Saber</Nickname>
-      <Description>DIRECT - ACT(&lt;color=#4CFF72&gt;RADAR&lt;/color&gt;) - HE FRAG</Description>
-      <LongDescription>The SGM-121 Saber is a size 1 direct guidance missile.  It is based on the SGM-1 body, which is a nimble general-purpose missile.  This missile will deliver a Proximity Fuze, High Explosive, Blast Fragmentation warhead.  It homes in on its target using an Active Radar seeker.
+      <Description>DIRECT - &lt;color=#FBFF4C&gt;CMD&lt;/color&gt; - HE FRAG</Description>
+      <LongDescription>The SGM-121 Saber is a size 1 direct guidance missile.  It is based on the SGM-1 body, which is a nimble general-purpose missile.  This missile will deliver a Proximity Fuze, High Explosive, Blast Fragmentation warhead.  It homes in on its target using command guidance from its launching ship.
 
 Control Method: DIRECT
 Targeting Modes:
-	&lt;b&gt;&lt;color=#4CFF72&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
-Primary Seeker: ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
+	&lt;b&gt;&lt;color=#FF2525&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
+Primary Seeker: COMMAND (&lt;color=#FBFF4C&gt;Requires COMMS Enabled&lt;/color&gt;)
 
-350 m/s for 4,116 m, top speed in 0.8 s
+285 m/s for 4,526 m, top speed in 0.7 s
 Terminal Maneuvers: None
 
 Proximity Fuze, High Explosive, Blast Fragmentation
-Armor: 1cm   Component: 48hp
-Blast Radius: 53 m
+Armor: 2cm   Component: 65hp
+Blast Radius: 47 m
 
 Body Integrity: 10 
 Programming Time: 6 s
@@ -489,29 +484,28 @@ Boost-Phase Duration: 3 s
 Boost-Phase Strafe: 100 %
 Boost-Phase Turn Rate: 100 %
 Failure Rate: 0 %</LongDescription>
-      <Cost>5</Cost>
+      <Cost>4</Cost>
       <BodyKey>Stock/SGM-1 Body</BodyKey>
       <TemplateKey>23757d9d-0ce7-4943-9887-0408a0500c39</TemplateKey>
       <BaseColor>
-        <r>1</r>
-        <g>0.4862745</g>
-        <b>0</b>
+        <r>0.3928509</r>
+        <g>0.3928509</g>
+        <b>0.3928509</b>
         <a>1</a>
       </BaseColor>
       <StripeColor>
-        <r>0.254901975</r>
-        <g>0.254901975</g>
-        <b>0.254901975</b>
+        <r>0.007352688</r>
+        <g>0.6173407</g>
+        <b>0.0193345789</b>
         <a>1</a>
       </StripeColor>
       <Sockets>
         <MissileSocket>
           <Size>1</Size>
-          <InstalledComponent xsi:type="ActiveSeekerSettings">
-            <ComponentKey>Stock/Steerable Active Radar Seeker</ComponentKey>
+          <InstalledComponent xsi:type="CommandSeekerSettings">
+            <ComponentKey>Stock/Command Receiver</ComponentKey>
             <Mode>Targeting</Mode>
             <RejectUnvalidated>false</RejectUnvalidated>
-            <DetectPDTargets>true</DetectPDTargets>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
@@ -524,6 +518,7 @@ Failure Rate: 0 %</LongDescription>
             <Maneuvers>None</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
@@ -532,19 +527,19 @@ Failure Rate: 0 %</LongDescription>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>3</Size>
+          <Size>4</Size>
           <InstalledComponent>
-            <ComponentKey>Stock/Blast Fragmentation EL</ComponentKey>
+            <ComponentKey>Stock/Blast Fragmentation</ComponentKey>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>4</Size>
+          <Size>3</Size>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.666998148</A>
-              <B>0.174186826</B>
-              <C>0.158815026</C>
+              <A>0.230625719</A>
+              <B>0.56861645</B>
+              <C>0.200757831</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>

--- a/data/fleets/TF Oak.fleet
+++ b/data/fleets/TF Oak.fleet
@@ -13,7 +13,7 @@ Dual heavy cruisers with all big guns. This fleet is ideal for those who struggl
       <SaveID xsi:nil="true" />
       <Key>15fe45e3-d169-402d-a6fa-4cf9e595c962</Key>
       <Name>Value Judgement</Name>
-      <Cost>1500</Cost>
+      <Cost>1499</Cost>
       <Callsign />
       <Number>451</Number>
       <SymbolOption>0</SymbolOption>
@@ -50,19 +50,6 @@ Dual heavy cruisers with all big guns. This fleet is ideal for those who struggl
         <HullSocket>
           <Key>LbD9Txe-S0a_nODTqtrk7g</Key>
           <ComponentName>Stock/RF101 'Bullseye' Radar</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>KxV0hkkGBE2AOUCo5axQbg</Key>
-          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
-          <ComponentData xsi:type="CellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>QoE_1Dz3bU28Bc5wRFwvzw</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>7</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-          </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>ylUvmASKlEiyCtyCsNRKWg</Key>
@@ -127,17 +114,21 @@ Dual heavy cruisers with all big guns. This fleet is ideal for those who struggl
               <MagSaveData>
                 <MagazineKey>GiE2Umbv2Ee2Swjls9HSFQ</MagazineKey>
                 <MunitionKey>Stock/Flak Round</MunitionKey>
-                <Quantity>750</Quantity>
+                <Quantity>450</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>SV_4BgcxwU24YIbep-k74g</Key>
-          <ComponentName>Stock/Damage Control Central</ComponentName>
+          <ComponentName>Stock/Small Workshop</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>A8e_Z_d8WU2qzo6HTQwCBA</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>2xmOS4ns_EaMYjBXrrhhig</Key>
           <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
@@ -162,7 +153,7 @@ Dual heavy cruisers with all big guns. This fleet is ideal for those who struggl
         </HullSocket>
         <HullSocket>
           <Key>2ZLEJvxYf0CATl1lBi3cuQ</Key>
-          <ComponentName>Stock/FM580 'Raider' Drive</ComponentName>
+          <ComponentName>Stock/FM500 Drive</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>ba-3VQ-zGEmDCfU12uaqaA</Key>
@@ -182,6 +173,10 @@ Dual heavy cruisers with all big guns. This fleet is ideal for those who struggl
         </HullSocket>
         <HullSocket>
           <Key>CgpRQa-660KEed1wTRL4vw</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>awwdeDnNs0G-RceQF1TByA</Key>
           <ComponentName>Stock/Mount Gyros</ComponentName>
         </HullSocket>
         <HullSocket>
@@ -212,7 +207,7 @@ Dual heavy cruisers with all big guns. This fleet is ideal for those who struggl
       <SaveID xsi:nil="true" />
       <Key>e0afb606-1caf-4f15-9abf-2d54ae422b5a</Key>
       <Name>Moral Failing</Name>
-      <Cost>1500</Cost>
+      <Cost>1501</Cost>
       <Callsign />
       <Number>452</Number>
       <SymbolOption>0</SymbolOption>
@@ -256,9 +251,9 @@ Dual heavy cruisers with all big guns. This fleet is ideal for those who struggl
           <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>QoE_1Dz3bU28Bc5wRFwvzw</MagazineKey>
+                <MagazineKey>DZUx10a3ZkWZEMBbh3nyvw</MagazineKey>
                 <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>17</Quantity>
+                <Quantity>7</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
@@ -326,17 +321,21 @@ Dual heavy cruisers with all big guns. This fleet is ideal for those who struggl
               <MagSaveData>
                 <MagazineKey>HEuAApq_8EGHF-ftJxu2Rg</MagazineKey>
                 <MunitionKey>Stock/Flak Round</MunitionKey>
-                <Quantity>750</Quantity>
+                <Quantity>450</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>SV_4BgcxwU24YIbep-k74g</Key>
-          <ComponentName>Stock/Damage Control Central</ComponentName>
+          <ComponentName>Stock/Small Workshop</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>A8e_Z_d8WU2qzo6HTQwCBA</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>2xmOS4ns_EaMYjBXrrhhig</Key>
           <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
@@ -361,7 +360,7 @@ Dual heavy cruisers with all big guns. This fleet is ideal for those who struggl
         </HullSocket>
         <HullSocket>
           <Key>2ZLEJvxYf0CATl1lBi3cuQ</Key>
-          <ComponentName>Stock/FM580 'Raider' Drive</ComponentName>
+          <ComponentName>Stock/FM500 Drive</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>ba-3VQ-zGEmDCfU12uaqaA</Key>
@@ -381,6 +380,10 @@ Dual heavy cruisers with all big guns. This fleet is ideal for those who struggl
         </HullSocket>
         <HullSocket>
           <Key>CgpRQa-660KEed1wTRL4vw</Key>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>awwdeDnNs0G-RceQF1TByA</Key>
           <ComponentName>Stock/Mount Gyros</ComponentName>
         </HullSocket>
         <HullSocket>
@@ -401,6 +404,14 @@ Dual heavy cruisers with all big guns. This fleet is ideal for those who struggl
           </MemberKeys>
         </WepGroup>
       </WeaponGroups>
+      <InitialFormation>
+        <GuideKey>15fe45e3-d169-402d-a6fa-4cf9e595c962</GuideKey>
+        <RelativePosition>
+          <x>22.4676476</x>
+          <y>21.2985153</y>
+          <z>0.004055023</z>
+        </RelativePosition>
+      </InitialFormation>
       <TemplateMissileTypes />
     </Ship>
   </Ships>

--- a/data/fleets/TF Redwood.fleet
+++ b/data/fleets/TF Redwood.fleet
@@ -6,189 +6,163 @@
   <FactionKey>Stock/Alliance</FactionKey>
   <Description>Difficulty: &lt;color=yellow&gt;MODERATE&lt;/color&gt;
 
-A sniper/spotter group with very capable scouts.  Designed to be used with the cruiser hanging back and providing long-range railgun fire support while the corvettes move ahead, as a group or individually, to spot targets.</Description>
+Featuring a core trio of railgun destroyers and a pair of sprinters to provide spotting and fire control, this fleet is designed to find and then deliver long range supporting fire against the enemy. The corvettes are built around employing Pinard emission-tracking modules to help the fleet find targets and Bullseye FCRs to lock onto them. While unable to defend themselves against larger vessels, the corvettes have offensive mini-missiles that can be used as self-defense against smaller enemies. It is advised that the fragile destroyers are kept away from dangerous threats. However, they can close on smaller ships or those sufficiently disabled by railgun fire and employ their 250mm cannon when the opportunity strikes.
+</Description>
   <SortOverrideOrder>5</SortOverrideOrder>
   <Ships>
     <Ship>
       <SaveID xsi:nil="true" />
-      <Key>5baa6874-c1bf-42b3-9152-aca90ec6c1c8</Key>
-      <Name>Southern Keep</Name>
-      <Cost>1599</Cost>
-      <Callsign />
-      <Number>864</Number>
-      <SymbolOption>0</SymbolOption>
-      <HullType>Stock/Axford Heavy Cruiser</HullType>
+      <Key>8d56faf8-3d0a-4391-8cbb-49e6aa3901b5</Key>
+      <Name>Star of Atlas</Name>
+      <Cost>870</Cost>
+      <Callsign>Intel/Radar</Callsign>
+      <Number>1000</Number>
+      <SymbolOption>2</SymbolOption>
+      <HullType>Stock/Keystone Destroyer</HullType>
       <SocketMap>
         <HullSocket>
-          <Key>whDP9rtbukKsocnrqnqaLQ</Key>
-          <ComponentName>Stock/Mk81 Railgun</ComponentName>
+          <Key>NpYYAkA5Z0uAElOjDg3Rag</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>8CtCKPLfZEOOFvm1DhV-oQ</Key>
-          <ComponentName>Stock/Mk81 Railgun</ComponentName>
+          <Key>fSYv4j5-eEObwJEVhoBSvg</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>N7yRYYUuG0uOzd5aufgViA</Key>
-          <ComponentName>Stock/Mk81 Railgun</ComponentName>
+          <Key>x21sadthgE2FtDWSJKINGQ</Key>
+          <ComponentName>Stock/Mk29 'Stonewall' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>lYEQo4jJvEGxRqJa2MB25A</Key>
-          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
+          <Key>IxKwpY5d9EicYRRTMn8xVw</Key>
+          <ComponentName>Stock/Mk29 'Stonewall' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>9qreGP2Iw0KwuloNpNFTSg</Key>
-          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>v9Sqa5DcCkibdi29AkakNg</Key>
-          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>3MoeYUx1HUS6xNDBMsssig</Key>
-          <ComponentName>Stock/Mk90 'Aurora' PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>LbD9Txe-S0a_nODTqtrk7g</Key>
-          <ComponentName>Stock/RF101 'Bullseye' Radar</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>KxV0hkkGBE2AOUCo5axQbg</Key>
+          <Key>JpOU9MgWXEmfLcQoAK4otA</Key>
           <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
           <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>17LmihVhGUSF1XN4v1HBRQ</MagazineKey>
+                <MagazineKey>rWDIVyJbk0Sjx5awMxewYg</MagazineKey>
+                <MunitionKey>Stock/EA99 Active Decoy</MunitionKey>
+                <Quantity>3</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>_lZGZIS7qkiw-Ef8zNEbHA</MagazineKey>
+                <MunitionKey>Stock/EA20 Flare Decoy</MunitionKey>
+                <Quantity>2</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>_IrnqFIbWk2SGgXg8zcVww</MagazineKey>
                 <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>23</Quantity>
+                <Quantity>3</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
         </HullSocket>
         <HullSocket>
-          <Key>ylUvmASKlEiyCtyCsNRKWg</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <Key>LCosRblddUCjPogeJ5eSeA</Key>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>TX2TktZe7EWB9s-MqlDQgA</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <Key>hGeid9yk80GqIN5IUlp8aw</Key>
+          <ComponentName>Stock/Mk550 Mass Driver</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>cMs0g0g3WUeZJQASb7omew</Key>
+          <Key>PlyaCcjDo0qu155JIZgm6A</Key>
           <ComponentName>Stock/Berthing</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>iHYg3DdYAUKS-uIBaRpNqA</Key>
-          <ComponentName>Stock/Citadel CIC</ComponentName>
+          <Key>ytRGy84X_kW1odHYCBICDQ</Key>
+          <ComponentName>Stock/Intelligence Center</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>j2ST2yYfwk2_tBIayI3sQg</Key>
-          <ComponentName>Stock/Plant Control Center</ComponentName>
+          <Key>yM3Am4PqyUOIByTKzM6sPA</Key>
+          <ComponentName>Stock/Reinforced CIC</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>SV_4BgcxwU24YIbep-k74g</Key>
-          <ComponentName>Stock/Plant Control Center</ComponentName>
+          <Key>H1ekC2-9c02VyNXY4IeLYA</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>A8e_Z_d8WU2qzo6HTQwCBA</Key>
+          <Key>ln5c_ZvdCUSMVWZL_-m3yw</Key>
           <ComponentName>Stock/Reinforced Magazine</ComponentName>
           <ComponentData xsi:type="BulkMagazineData">
             <Load>
               <MagSaveData>
-                <MagazineKey>MT-zapEtR0-qye1z6MgHFQ</MagazineKey>
+                <MagazineKey>mS8khaGWWEKe9VwlCjXHhQ</MagazineKey>
                 <MunitionKey>Stock/300mm AP Rail Sabot</MunitionKey>
-                <Quantity>320</Quantity>
+                <Quantity>150</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>Z_hycRyIGUuA6zmhoCEMhw</MagazineKey>
+                <MunitionKey>Stock/Flak Round</MunitionKey>
+                <Quantity>675</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>roE4Gtkc9EGlhIWWdcJKsg</MagazineKey>
+                <MunitionKey>Stock/20mm Slug</MunitionKey>
+                <Quantity>6000</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>lBA4WM4NrUaLJE_TmT8zIw</MagazineKey>
+                <MunitionKey>Stock/250mm HE-RPF Shell</MunitionKey>
+                <Quantity>150</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>vlcOfEdwMES_yWHJbgnojA</MagazineKey>
+                <MunitionKey>Stock/250mm HE Shell</MunitionKey>
+                <Quantity>150</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>csTEo4G8_kiUlVWOR4aTXA</MagazineKey>
+                <MunitionKey>Stock/250mm AP Shell</MunitionKey>
+                <Quantity>100</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
         </HullSocket>
         <HullSocket>
-          <Key>2xmOS4ns_EaMYjBXrrhhig</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <Key>H-oABJbYw0qgKd4QzU0WaA</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>y1xLixKUzUSKT7Nz7aUkLQ</Key>
-          <ComponentName>Stock/Reinforced Magazine</ComponentName>
-          <ComponentData xsi:type="BulkMagazineData">
-            <Load>
-              <MagSaveData>
-                <MagazineKey>soOYETXUCUqlOLP-lubBFA</MagazineKey>
-                <MunitionKey>Stock/300mm AP Rail Sabot</MunitionKey>
-                <Quantity>400</Quantity>
-              </MagSaveData>
-            </Load>
-          </ComponentData>
+          <Key>tCBEdcIUhk6AL-X6sCujsQ</Key>
+          <ComponentName>Stock/Gun Plotting Center</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>RmUeePb-8EGbFaRgVjCXsA</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>eYp1IPfupUGVITrkVhgZJw</Key>
-          <ComponentName>Stock/Berthing</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>lxkgmNwqjUua0sRee2pDJg</Key>
+          <Key>AWYvQUZ26k20yHOrVQKg6Q</Key>
           <ComponentName>Stock/FR4800 Reactor</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>_Aun-HW-DkOGytVmYSn5IQ</Key>
+          <Key>tmHTz6HkrE-RUtN94W6lyQ</Key>
           <ComponentName>Stock/FM240 'Dragonfly' Drive</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>2ZLEJvxYf0CATl1lBi3cuQ</Key>
-          <ComponentName>Stock/FM230 'Whiplash' Drive</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>ba-3VQ-zGEmDCfU12uaqaA</Key>
-          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>hQ-Mzyns0UO4oMp7gG0d8A</Key>
+          <Key>m5J1jQdOfUKM9r7NZjMpKA</Key>
           <ComponentName>Stock/Energy Regulator</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>oyAxfnepkEG46VjtvQWXpw</Key>
-          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
+          <Key>h29TSNGRo0m_DmeRr2BqDw</Key>
+          <ComponentName>Stock/Energy Regulator</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>Yo9hPw6Mf060B3vqwSO4GA</Key>
-          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
+          <Key>E9sMCEquVk-NNj5heGmIlQ</Key>
+          <ComponentName>Stock/Adaptive Radar Receiver</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>CgpRQa-660KEed1wTRL4vw</Key>
-          <ComponentName>Stock/Small Energy Regulator</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>awwdeDnNs0G-RceQF1TByA</Key>
-          <ComponentName>Stock/Small Energy Regulator</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>tnZD-B5Ls0qAyBtdz4yoTA</Key>
-          <ComponentName>Stock/Small Energy Regulator</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>S8ALcpOMYEqJog1v2q8UMQ</Key>
+          <Key>gx2UKetKWUm5BfZhiD5phQ</Key>
           <ComponentName>Stock/RM50 'Parallax' Radar</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>rQWETsDGdE-AR8N3NPfwXg</Key>
-          <ComponentName>Stock/Small Reactor Booster</ComponentName>
+          <Key>ZJTmbGdjAk-XEKihIYHEuw</Key>
+          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
         </HullSocket>
       </SocketMap>
       <WeaponGroups>
-        <WepGroup Name="Front">
+        <WepGroup Name="Gun!">
           <MemberKeys>
-            <string>whDP9rtbukKsocnrqnqaLQ</string>
-          </MemberKeys>
-        </WepGroup>
-        <WepGroup Name="Back">
-          <MemberKeys>
-            <string>8CtCKPLfZEOOFvm1DhV-oQ</string>
-          </MemberKeys>
-        </WepGroup>
-        <WepGroup Name="Buttom">
-          <MemberKeys>
-            <string>N7yRYYUuG0uOzd5aufgViA</string>
+            <string>NpYYAkA5Z0uAElOjDg3Rag</string>
+            <string>fSYv4j5-eEObwJEVhoBSvg</string>
           </MemberKeys>
         </WepGroup>
       </WeaponGroups>
@@ -196,11 +170,325 @@ A sniper/spotter group with very capable scouts.  Designed to be used with the c
     </Ship>
     <Ship>
       <SaveID xsi:nil="true" />
-      <Key>ab5710ac-bd76-4d4c-a801-88a77d2cdb8f</Key>
-      <Name>Oculus</Name>
-      <Cost>265</Cost>
-      <Callsign>E-Scout</Callsign>
-      <Number>116</Number>
+      <Key>f943a009-15b6-48d9-8ce9-b4a9425ab0ba</Key>
+      <Name>Arc of Solitas</Name>
+      <Cost>730</Cost>
+      <Callsign>Rail-1</Callsign>
+      <Number>2000</Number>
+      <SymbolOption>0</SymbolOption>
+      <HullType>Stock/Keystone Destroyer</HullType>
+      <SocketMap>
+        <HullSocket>
+          <Key>NpYYAkA5Z0uAElOjDg3Rag</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>fSYv4j5-eEObwJEVhoBSvg</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>x21sadthgE2FtDWSJKINGQ</Key>
+          <ComponentName>Stock/Mk29 'Stonewall' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>IxKwpY5d9EicYRRTMn8xVw</Key>
+          <ComponentName>Stock/Mk29 'Stonewall' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>JpOU9MgWXEmfLcQoAK4otA</Key>
+          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
+            <MissileLoad>
+              <MagSaveData>
+                <MagazineKey>bR3wteR0_ka6yLfn-eqjUQ</MagazineKey>
+                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
+                <Quantity>5</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>jTEwMuqvsUeAG0PZXMksEg</MagazineKey>
+                <MunitionKey>Stock/EA20 Flare Decoy</MunitionKey>
+                <Quantity>2</Quantity>
+              </MagSaveData>
+            </MissileLoad>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>LCosRblddUCjPogeJ5eSeA</Key>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>hGeid9yk80GqIN5IUlp8aw</Key>
+          <ComponentName>Stock/Mk550 Mass Driver</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>PlyaCcjDo0qu155JIZgm6A</Key>
+          <ComponentName>Stock/Berthing</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>ytRGy84X_kW1odHYCBICDQ</Key>
+          <ComponentName>Stock/Gun Plotting Center</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>yM3Am4PqyUOIByTKzM6sPA</Key>
+          <ComponentName>Stock/Basic CIC</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>H1ekC2-9c02VyNXY4IeLYA</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>ln5c_ZvdCUSMVWZL_-m3yw</Key>
+          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>mS8khaGWWEKe9VwlCjXHhQ</MagazineKey>
+                <MunitionKey>Stock/300mm AP Rail Sabot</MunitionKey>
+                <Quantity>200</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>Z_hycRyIGUuA6zmhoCEMhw</MagazineKey>
+                <MunitionKey>Stock/Flak Round</MunitionKey>
+                <Quantity>675</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>ZOICjA17LkKdWCVtLABPbw</MagazineKey>
+                <MunitionKey>Stock/20mm Slug</MunitionKey>
+                <Quantity>6000</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>00LI9InExEG_22z3cn4pJg</MagazineKey>
+                <MunitionKey>Stock/250mm HE-RPF Shell</MunitionKey>
+                <Quantity>150</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>RWX3Z_WAhk-F752xygzNtA</MagazineKey>
+                <MunitionKey>Stock/250mm HE Shell</MunitionKey>
+                <Quantity>150</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>ngS3RahesEqc-LAFWvQ4tQ</MagazineKey>
+                <MunitionKey>Stock/250mm AP Shell</MunitionKey>
+                <Quantity>100</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>H-oABJbYw0qgKd4QzU0WaA</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>AWYvQUZ26k20yHOrVQKg6Q</Key>
+          <ComponentName>Stock/FR4800 Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>tmHTz6HkrE-RUtN94W6lyQ</Key>
+          <ComponentName>Stock/FM240 'Dragonfly' Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>m5J1jQdOfUKM9r7NZjMpKA</Key>
+          <ComponentName>Stock/Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>h29TSNGRo0m_DmeRr2BqDw</Key>
+          <ComponentName>Stock/Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>E9sMCEquVk-NNj5heGmIlQ</Key>
+          <ComponentName>Stock/Small Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gx2UKetKWUm5BfZhiD5phQ</Key>
+          <ComponentName>Stock/Small Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>ZJTmbGdjAk-XEKihIYHEuw</Key>
+          <ComponentName>Stock/Energy Regulator</ComponentName>
+        </HullSocket>
+      </SocketMap>
+      <WeaponGroups>
+        <WepGroup Name="Gun!">
+          <MemberKeys>
+            <string>NpYYAkA5Z0uAElOjDg3Rag</string>
+            <string>fSYv4j5-eEObwJEVhoBSvg</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
+      <InitialFormation>
+        <GuideKey>8d56faf8-3d0a-4391-8cbb-49e6aa3901b5</GuideKey>
+        <RelativePosition>
+          <x>30.2194366</x>
+          <y>39.38228</y>
+          <z>0.104979515</z>
+        </RelativePosition>
+      </InitialFormation>
+      <TemplateMissileTypes />
+    </Ship>
+    <Ship>
+      <SaveID xsi:nil="true" />
+      <Key>098344c3-783c-4d43-9db3-00e45d1b8de0</Key>
+      <Name>Singing Mantle</Name>
+      <Cost>730</Cost>
+      <Callsign>Rail-2</Callsign>
+      <Number>2500</Number>
+      <SymbolOption>0</SymbolOption>
+      <HullType>Stock/Keystone Destroyer</HullType>
+      <SocketMap>
+        <HullSocket>
+          <Key>NpYYAkA5Z0uAElOjDg3Rag</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>fSYv4j5-eEObwJEVhoBSvg</Key>
+          <ComponentName>Stock/Mk64 Cannon</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>x21sadthgE2FtDWSJKINGQ</Key>
+          <ComponentName>Stock/Mk29 'Stonewall' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>IxKwpY5d9EicYRRTMn8xVw</Key>
+          <ComponentName>Stock/Mk29 'Stonewall' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>JpOU9MgWXEmfLcQoAK4otA</Key>
+          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
+            <MissileLoad>
+              <MagSaveData>
+                <MagazineKey>dWlwYD2vBEaY2xrt1R38RA</MagazineKey>
+                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
+                <Quantity>5</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>eNzfz1hQIUiUwAp3LI9h1g</MagazineKey>
+                <MunitionKey>Stock/EA20 Flare Decoy</MunitionKey>
+                <Quantity>2</Quantity>
+              </MagSaveData>
+            </MissileLoad>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>LCosRblddUCjPogeJ5eSeA</Key>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>hGeid9yk80GqIN5IUlp8aw</Key>
+          <ComponentName>Stock/Mk550 Mass Driver</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>PlyaCcjDo0qu155JIZgm6A</Key>
+          <ComponentName>Stock/Berthing</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>ytRGy84X_kW1odHYCBICDQ</Key>
+          <ComponentName>Stock/Gun Plotting Center</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>yM3Am4PqyUOIByTKzM6sPA</Key>
+          <ComponentName>Stock/Basic CIC</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>H1ekC2-9c02VyNXY4IeLYA</Key>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>ln5c_ZvdCUSMVWZL_-m3yw</Key>
+          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>mS8khaGWWEKe9VwlCjXHhQ</MagazineKey>
+                <MunitionKey>Stock/300mm AP Rail Sabot</MunitionKey>
+                <Quantity>200</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>Z_hycRyIGUuA6zmhoCEMhw</MagazineKey>
+                <MunitionKey>Stock/Flak Round</MunitionKey>
+                <Quantity>675</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>ZOICjA17LkKdWCVtLABPbw</MagazineKey>
+                <MunitionKey>Stock/20mm Slug</MunitionKey>
+                <Quantity>6000</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>0PU11oIUW0OvQB61jzYa2Q</MagazineKey>
+                <MunitionKey>Stock/250mm HE-RPF Shell</MunitionKey>
+                <Quantity>150</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>Oy0sO0o-sUaQPK2pokAVkg</MagazineKey>
+                <MunitionKey>Stock/250mm HE Shell</MunitionKey>
+                <Quantity>150</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>VUTKqa3mzUeBQbsqZt22Mw</MagazineKey>
+                <MunitionKey>Stock/250mm AP Shell</MunitionKey>
+                <Quantity>100</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>H-oABJbYw0qgKd4QzU0WaA</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>AWYvQUZ26k20yHOrVQKg6Q</Key>
+          <ComponentName>Stock/FR4800 Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>tmHTz6HkrE-RUtN94W6lyQ</Key>
+          <ComponentName>Stock/FM240 'Dragonfly' Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>m5J1jQdOfUKM9r7NZjMpKA</Key>
+          <ComponentName>Stock/Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>h29TSNGRo0m_DmeRr2BqDw</Key>
+          <ComponentName>Stock/Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>E9sMCEquVk-NNj5heGmIlQ</Key>
+          <ComponentName>Stock/Small Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gx2UKetKWUm5BfZhiD5phQ</Key>
+          <ComponentName>Stock/Small Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>ZJTmbGdjAk-XEKihIYHEuw</Key>
+          <ComponentName>Stock/Energy Regulator</ComponentName>
+        </HullSocket>
+      </SocketMap>
+      <WeaponGroups>
+        <WepGroup Name="Gun!">
+          <MemberKeys>
+            <string>NpYYAkA5Z0uAElOjDg3Rag</string>
+            <string>fSYv4j5-eEObwJEVhoBSvg</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
+      <InitialFormation>
+        <GuideKey>8d56faf8-3d0a-4391-8cbb-49e6aa3901b5</GuideKey>
+        <RelativePosition>
+          <x>-30.1803036</x>
+          <y>40.1105957</y>
+          <z>0.37345314</z>
+        </RelativePosition>
+      </InitialFormation>
+      <TemplateMissileTypes />
+    </Ship>
+    <Ship>
+      <SaveID xsi:nil="true" />
+      <Key>d74962dc-a197-44c4-b8e0-086cf68a457b</Key>
+      <Name>Northern Wind</Name>
+      <Cost>335</Cost>
+      <Callsign>Scout-1</Callsign>
+      <Number>610</Number>
       <SymbolOption>0</SymbolOption>
       <HullType>Stock/Sprinter Corvette</HullType>
       <SocketMap>
@@ -209,16 +497,79 @@ A sniper/spotter group with very capable scouts.  Designed to be used with the c
           <ComponentName>Stock/ES22 'Pinard' Electronic Support Module</ComponentName>
         </HullSocket>
         <HullSocket>
+          <Key>Z48ot_dQfkWb6AVYjaM_gA</Key>
+          <ComponentName>Stock/RF101 'Bullseye' Radar</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>IUdNSVZm2Eu9n3F5HnSAng</Key>
+          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
+            <MissileLoad>
+              <MagSaveData>
+                <MagazineKey>-bl4YQa7SU-zZ2TA4ajlZg</MagazineKey>
+                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
+                <Quantity>3</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>M3kLFQim70qQlGjimE-jOA</MagazineKey>
+                <MunitionKey>Stock/EA99 Active Decoy</MunitionKey>
+                <Quantity>1</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>i1U0oG2nukW9T7zqo7M9-w</MagazineKey>
+                <MunitionKey>Stock/EA20 Flare Decoy</MunitionKey>
+                <Quantity>2</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>nUDVayKo7kKzd7SoqqiHPQ</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-133 'Red Scythe' Anti-Clipper</MunitionKey>
+                <Quantity>5</Quantity>
+              </MagSaveData>
+            </MissileLoad>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>ZxY9ONYz80SiLNSObvjNzQ</Key>
+          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
+            <MissileLoad>
+              <MagSaveData>
+                <MagazineKey>wF0cRohjTEOgu5sSmvs6jA</MagazineKey>
+                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
+                <Quantity>3</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>RNXiy_Ck-U2pQGOxJx0h8A</MagazineKey>
+                <MunitionKey>Stock/EA99 Active Decoy</MunitionKey>
+                <Quantity>1</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>jiGGqMBZO0Cb_MEMTKSURg</MagazineKey>
+                <MunitionKey>Stock/EA20 Flare Decoy</MunitionKey>
+                <Quantity>1</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>z59mJGROtkWMbk_JdsPyrw</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-133 'Red Scythe' Anti-Clipper</MunitionKey>
+                <Quantity>5</Quantity>
+              </MagSaveData>
+            </MissileLoad>
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
           <Key>XPaYCjBqdEqBxEIsVLP0oA</Key>
-          <ComponentName>Stock/Basic CIC</ComponentName>
+          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load />
+          </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>xRYIkvssd0mPY3VIgrnQ5A</Key>
-          <ComponentName>Stock/Plant Control Center</ComponentName>
+          <ComponentName>Stock/Basic CIC</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>rXO8xwG1MkqzI_2pU-O_qQ</Key>
-          <ComponentName>Stock/Plant Control Center</ComponentName>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>GefqwCQzg0qXA3EFRmDtPw</Key>
@@ -234,7 +585,7 @@ A sniper/spotter group with very capable scouts.  Designed to be used with the c
         </HullSocket>
         <HullSocket>
           <Key>TSPPW9ECe06-MGzR1i0WvQ</Key>
-          <ComponentName>Stock/RM50 'Parallax' Radar</ComponentName>
+          <ComponentName>Stock/RS35 'Frontline' Radar</ComponentName>
         </HullSocket>
       </SocketMap>
       <WeaponGroups />
@@ -242,185 +593,96 @@ A sniper/spotter group with very capable scouts.  Designed to be used with the c
     </Ship>
     <Ship>
       <SaveID xsi:nil="true" />
-      <Key>9650670e-2f79-4a83-ba25-00e7178a5cb9</Key>
-      <Name>Gladius</Name>
-      <Cost>589</Cost>
-      <Callsign>M-Scout</Callsign>
-      <Number>873</Number>
+      <Key>3a972c1a-7004-4cef-8f90-f7583070bfa4</Key>
+      <Name>Southern Squall</Name>
+      <Cost>335</Cost>
+      <Callsign>Scout-2</Callsign>
+      <Number>89</Number>
       <SymbolOption>0</SymbolOption>
       <HullType>Stock/Sprinter Corvette</HullType>
       <SocketMap>
         <HullSocket>
           <Key>wDsRnL5nKkyYvKgD6VcPHg</Key>
-          <ComponentName>Stock/VLS-2 Launcher</ComponentName>
-          <ComponentData xsi:type="ResizableCellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>TO0MvkKgvkyokZbxE1izrg</MagazineKey>
-                <MunitionKey>$MODMIS$/SGM-206 Thunderhead</MunitionKey>
-                <Quantity>20</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>a_QhmDfbukaTB8CBdEEnoA</MagazineKey>
-                <MunitionKey>$MODMIS$/SGM-H-201 DeathWish</MunitionKey>
-                <Quantity>4</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-            <ConfiguredSize>
-              <x>1</x>
-              <y>3</y>
-            </ConfiguredSize>
-          </ComponentData>
+          <ComponentName>Stock/ES22 'Pinard' Electronic Support Module</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>Z48ot_dQfkWb6AVYjaM_gA</Key>
-          <ComponentName>Stock/VLS-1-46 Launcher</ComponentName>
-          <ComponentData xsi:type="CellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>hFq0yJvKFkW8cp30sh44iQ</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>4</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>-x7n0JRCiUqmI49OHPXR-w</MagazineKey>
-                <MunitionKey>$MODMIS$/SGM-112 Riposte</MunitionKey>
-                <Quantity>23</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>IUdNSVZm2Eu9n3F5HnSAng</Key>
           <ComponentName>Stock/RF101 'Bullseye' Radar</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>ZxY9ONYz80SiLNSObvjNzQ</Key>
-          <ComponentName>Stock/E71 'Hangup' Jammer</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>XPaYCjBqdEqBxEIsVLP0oA</Key>
-          <ComponentName>Stock/Basic CIC</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>xRYIkvssd0mPY3VIgrnQ5A</Key>
-          <ComponentName>Stock/Plant Control Center</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>rXO8xwG1MkqzI_2pU-O_qQ</Key>
-          <ComponentName>Stock/Berthing</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>GefqwCQzg0qXA3EFRmDtPw</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>4WpJyiOKVEqCwR99l47MkA</Key>
-          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>4EHx4mQhNUi-WuuQtQF5fA</Key>
-          <ComponentName>Stock/FM230 'Whiplash' Drive</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>TSPPW9ECe06-MGzR1i0WvQ</Key>
-          <ComponentName>Stock/RS35 'Frontline' Radar</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>MBOvGazj6UWpt2OOy44s7w</Key>
-          <ComponentName>Stock/Missile Programming Bus</ComponentName>
-        </HullSocket>
-      </SocketMap>
-      <WeaponGroups>
-        <WepGroup Name="HangUp">
-          <MemberKeys>
-            <string>ZxY9ONYz80SiLNSObvjNzQ</string>
-          </MemberKeys>
-        </WepGroup>
-      </WeaponGroups>
-      <InitialFormation>
-        <GuideKey>ab5710ac-bd76-4d4c-a801-88a77d2cdb8f</GuideKey>
-        <RelativePosition>
-          <x>31.1435928</x>
-          <y>0</y>
-          <z>-25.9803162</z>
-        </RelativePosition>
-      </InitialFormation>
-      <TemplateMissileTypes />
-    </Ship>
-    <Ship>
-      <SaveID xsi:nil="true" />
-      <Key>1698d907-74a3-4e13-bcfd-988002f1d08b</Key>
-      <Name>Deceptio</Name>
-      <Cost>547</Cost>
-      <Callsign>J-Scout</Callsign>
-      <Number>54</Number>
-      <SymbolOption>0</SymbolOption>
-      <HullType>Stock/Sprinter Corvette</HullType>
-      <SocketMap>
-        <HullSocket>
-          <Key>wDsRnL5nKkyYvKgD6VcPHg</Key>
-          <ComponentName>Stock/VLS-2 Launcher</ComponentName>
-          <ComponentData xsi:type="ResizableCellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>D79spz1PdkOhGB5Wuwro6Q</MagazineKey>
-                <MunitionKey>$MODMIS$/SGM-206 Thunderhead</MunitionKey>
-                <Quantity>22</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>qMDuXPFkyU-LigJZfcy4wg</MagazineKey>
-                <MunitionKey>$MODMIS$/SGM-H-201 DeathWish</MunitionKey>
-                <Quantity>2</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-            <ConfiguredSize>
-              <x>1</x>
-              <y>3</y>
-            </ConfiguredSize>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>Z48ot_dQfkWb6AVYjaM_gA</Key>
-          <ComponentName>Stock/VLS-1-46 Launcher</ComponentName>
+          <Key>IUdNSVZm2Eu9n3F5HnSAng</Key>
+          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
           <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>O_Cbf7jE2EiAMAyod8T04g</MagazineKey>
-                <MunitionKey>$MODMIS$/SGM-112 Riposte</MunitionKey>
-                <Quantity>15</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>v7F8lS26sUCzgTGNwlcs3Q</MagazineKey>
+                <MagazineKey>-bl4YQa7SU-zZ2TA4ajlZg</MagazineKey>
                 <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
                 <Quantity>3</Quantity>
               </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>M3kLFQim70qQlGjimE-jOA</MagazineKey>
+                <MunitionKey>Stock/EA99 Active Decoy</MunitionKey>
+                <Quantity>1</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>i1U0oG2nukW9T7zqo7M9-w</MagazineKey>
+                <MunitionKey>Stock/EA20 Flare Decoy</MunitionKey>
+                <Quantity>2</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>33Bq7npC6EGZOzYVtLqipQ</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-133 'Red Scythe' Anti-Clipper</MunitionKey>
+                <Quantity>5</Quantity>
+              </MagSaveData>
             </MissileLoad>
           </ComponentData>
         </HullSocket>
         <HullSocket>
-          <Key>IUdNSVZm2Eu9n3F5HnSAng</Key>
-          <ComponentName>Stock/RF101 'Bullseye' Radar</ComponentName>
-        </HullSocket>
-        <HullSocket>
           <Key>ZxY9ONYz80SiLNSObvjNzQ</Key>
-          <ComponentName>Stock/E90 'Blanket' Jammer</ComponentName>
+          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
+            <MissileLoad>
+              <MagSaveData>
+                <MagazineKey>T7Xj_2obyUCJ_nYFmOq87w</MagazineKey>
+                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
+                <Quantity>3</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>GwlE5S-LFEaptsbHlY8riQ</MagazineKey>
+                <MunitionKey>Stock/EA99 Active Decoy</MunitionKey>
+                <Quantity>1</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>qYOvnYuUdkq3uTf6R3nAiQ</MagazineKey>
+                <MunitionKey>Stock/EA20 Flare Decoy</MunitionKey>
+                <Quantity>1</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>9VysatVey0yzklFwz7zaPA</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-133 'Red Scythe' Anti-Clipper</MunitionKey>
+                <Quantity>5</Quantity>
+              </MagSaveData>
+            </MissileLoad>
+          </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>XPaYCjBqdEqBxEIsVLP0oA</Key>
-          <ComponentName>Stock/Basic CIC</ComponentName>
+          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load />
+          </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>xRYIkvssd0mPY3VIgrnQ5A</Key>
-          <ComponentName>Stock/Plant Control Center</ComponentName>
+          <ComponentName>Stock/Basic CIC</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>rXO8xwG1MkqzI_2pU-O_qQ</Key>
-          <ComponentName>Stock/Berthing</ComponentName>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>GefqwCQzg0qXA3EFRmDtPw</Key>
-          <ComponentName>Stock/Plant Control Center</ComponentName>
+          <ComponentName>Stock/Berthing</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>4WpJyiOKVEqCwR99l47MkA</Key>
@@ -434,98 +696,78 @@ A sniper/spotter group with very capable scouts.  Designed to be used with the c
           <Key>TSPPW9ECe06-MGzR1i0WvQ</Key>
           <ComponentName>Stock/RS35 'Frontline' Radar</ComponentName>
         </HullSocket>
-        <HullSocket>
-          <Key>MBOvGazj6UWpt2OOy44s7w</Key>
-          <ComponentName>Stock/Actively Cooled Amplifiers</ComponentName>
-        </HullSocket>
       </SocketMap>
-      <WeaponGroups>
-        <WepGroup Name="Jammer">
-          <MemberKeys>
-            <string>ZxY9ONYz80SiLNSObvjNzQ</string>
-          </MemberKeys>
-        </WepGroup>
-      </WeaponGroups>
-      <InitialFormation>
-        <GuideKey>ab5710ac-bd76-4d4c-a801-88a77d2cdb8f</GuideKey>
-        <RelativePosition>
-          <x>-31.44532</x>
-          <y>0</y>
-          <z>-25.1550446</z>
-        </RelativePosition>
-      </InitialFormation>
+      <WeaponGroups />
       <TemplateMissileTypes />
     </Ship>
   </Ships>
   <MissileTypes>
     <MissileTemplate>
-      <AssociatedTemplateName>SGM-206 Thunderhead</AssociatedTemplateName>
-      <Designation>SGM-206</Designation>
-      <Nickname>Thunderhead</Nickname>
-      <Description>CRUISE - ACT(&lt;color=#4CFF72&gt;RADAR&lt;/color&gt;) - HE SHAPED</Description>
-      <LongDescription>The SGM-206 Thunderhead is a size 2 waypoint-capable cruise missile.  It is based on the SGM-2 body, which is a flexible mainstay anti-ship missile.  This missile will deliver a Contact Fuze, High Explosive, Shaped warhead.  It homes in on its target using an Active Radar seeker.
+      <Designation>SGM-133</Designation>
+      <Nickname>'Red Scythe' Anti-Clipper</Nickname>
+      <Description>DIRECT - &lt;color=#FBFF4C&gt;CMD&lt;/color&gt; - HE SHAPED</Description>
+      <LongDescription>The SGM-133 'Red Scythe' Anti-Clipper is a size 1 direct guidance missile.  It is based on the SGM-1 body, which is a nimble general-purpose missile.  This missile will deliver a Contact Fuze, High Explosive, Shaped warhead.  It homes in on its target using command guidance from its launching ship.
 
-Control Method: CRUISE (Waypoint Capable)
+Control Method: DIRECT
 Targeting Modes:
-	&lt;b&gt;&lt;color=#4CFF72&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK[+TRP]&lt;/color&gt;&lt;/b&gt;
-Primary Seeker: ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
+	&lt;b&gt;&lt;color=#FF2525&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
+Primary Seeker: COMMAND (&lt;color=#FBFF4C&gt;Requires COMMS Enabled&lt;/color&gt;)
 
-200 m/s for 14,040 m, top speed in 1.1 s
-Terminal Maneuvers: None
+300 m/s for 4,500 m, top speed in 0.7 s
+Terminal Maneuvers: Corkscrew
 
 Contact Fuze, High Explosive, Shaped
-Armor: 54cm   Component: 960hp
+Armor: 31cm   Component: 317hp
 Blast Angle: 70 deg
+Damage Per Fragment: 50.0
 
-Body Integrity: 30 
-Programming Time: 8 s
+Body Integrity: 10 
+Programming Time: 6 s
 Radar Signature Bonus: 100 %
 Boost-Phase Duration: 3 s
 Boost-Phase Strafe: 100 %
 Boost-Phase Turn Rate: 100 %
 Failure Rate: 0 %</LongDescription>
-      <Cost>6</Cost>
-      <BodyKey>Stock/SGM-2 Body</BodyKey>
-      <TemplateKey>2882048f-862c-45f1-839d-128132ed441c</TemplateKey>
+      <Cost>7</Cost>
+      <BodyKey>Stock/SGM-1 Body</BodyKey>
+      <TemplateKey>ef6cf8bf-99e4-401c-8ee0-e0abf86526b6</TemplateKey>
       <BaseColor>
-        <r>1</r>
-        <g>1</g>
-        <b>1</b>
+        <r>0.9999999</r>
+        <g>0</g>
+        <b>0</b>
         <a>1</a>
       </BaseColor>
       <StripeColor>
-        <r>0.7058824</r>
-        <g>0.129411772</g>
-        <b>0.129411772</b>
+        <r>-7.07805157E-08</r>
+        <g>-0</g>
+        <b>-6.14209839E-08</b>
         <a>1</a>
       </StripeColor>
       <Sockets>
         <MissileSocket>
           <Size>1</Size>
-          <InstalledComponent xsi:type="ActiveSeekerSettings">
-            <ComponentKey>Stock/Fixed Active Radar Seeker</ComponentKey>
+          <InstalledComponent xsi:type="CommandSeekerSettings">
+            <ComponentKey>Stock/Command Receiver</ComponentKey>
             <Mode>Targeting</Mode>
             <RejectUnvalidated>false</RejectUnvalidated>
-            <DetectPDTargets>false</DetectPDTargets>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
           <Size>1</Size>
-        </MissileSocket>
-        <MissileSocket>
-          <Size>1</Size>
-          <InstalledComponent xsi:type="CruiseGuidanceSettings">
-            <ComponentKey>Stock/Cruise Guidance</ComponentKey>
+          <InstalledComponent xsi:type="DirectGuidanceSettings">
+            <ComponentKey>Stock/Direct Guidance</ComponentKey>
             <Role>Offensive</Role>
-            <HotLaunch>false</HotLaunch>
+            <HotLaunch>true</HotLaunch>
             <SelfDestructOnLost>false</SelfDestructOnLost>
-            <Maneuvers>None</Maneuvers>
+            <Maneuvers>Corkscrew</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
             </DefensiveDoctrine>
+            <ApproachAngleControl>true</ApproachAngleControl>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
@@ -535,205 +777,13 @@ Failure Rate: 0 %</LongDescription>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>6</Size>
+          <Size>3</Size>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.248382539</A>
-              <B>0.488160223</B>
-              <C>0.263457239</C>
-            </BalanceValues>
-          </InstalledComponent>
-        </MissileSocket>
-      </Sockets>
-    </MissileTemplate>
-    <MissileTemplate>
-      <AssociatedTemplateName>SGM-112 Riposte</AssociatedTemplateName>
-      <Designation>SGM-112</Designation>
-      <Nickname>Riposte</Nickname>
-      <Description>DIRECT - ACT(&lt;color=#4CFF72&gt;RADAR&lt;/color&gt;) - HE FRAG</Description>
-      <LongDescription>The SGM-112 Riposte is a size 1 direct guidance missile.  It is based on the SGM-1 body, which is a nimble general-purpose missile.  This missile will deliver a Proximity Fuze, High Explosive, Blast Fragmentation warhead.  It homes in on its target using an Active Radar seeker.
-
-Control Method: DIRECT
-Targeting Modes:
-	&lt;b&gt;&lt;color=#4CFF72&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
-Primary Seeker: ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
-
-335 m/s for 3,435 m, top speed in 0.7 s
-Terminal Maneuvers: None
-
-Proximity Fuze, High Explosive, Blast Fragmentation
-Armor: 1cm   Component: 40hp
-Blast Radius: 33 m
-
-Body Integrity: 10 
-Programming Time: 6 s
-Radar Signature Bonus: 100 %
-Boost-Phase Duration: 3 s
-Boost-Phase Strafe: 100 %
-Boost-Phase Turn Rate: 100 %
-Failure Rate: 0 %</LongDescription>
-      <Cost>2</Cost>
-      <BodyKey>Stock/SGM-1 Body</BodyKey>
-      <TemplateKey>f8cf77e3-f11c-4840-b773-c0f969af1916</TemplateKey>
-      <BaseColor>
-        <r>1</r>
-        <g>0.4862745</g>
-        <b>0</b>
-        <a>1</a>
-      </BaseColor>
-      <StripeColor>
-        <r>0.254901975</r>
-        <g>0.254901975</g>
-        <b>0.254901975</b>
-        <a>1</a>
-      </StripeColor>
-      <Sockets>
-        <MissileSocket>
-          <Size>1</Size>
-          <InstalledComponent xsi:type="ActiveSeekerSettings">
-            <ComponentKey>Stock/Fixed Active Radar Seeker</ComponentKey>
-            <Mode>Targeting</Mode>
-            <RejectUnvalidated>false</RejectUnvalidated>
-            <DetectPDTargets>false</DetectPDTargets>
-          </InstalledComponent>
-        </MissileSocket>
-        <MissileSocket>
-          <Size>1</Size>
-          <InstalledComponent xsi:type="DirectGuidanceSettings">
-            <ComponentKey>Stock/Direct Guidance</ComponentKey>
-            <Role>Defensive</Role>
-            <HotLaunch>true</HotLaunch>
-            <SelfDestructOnLost>false</SelfDestructOnLost>
-            <Maneuvers>None</Maneuvers>
-            <DefensiveDoctrine>
-              <TargetSizeMask>12</TargetSizeMask>
-              <TargetSizeOrdering>Descending</TargetSizeOrdering>
-              <SalvoSize>0</SalvoSize>
-              <FarthestFirst>false</FarthestFirst>
-            </DefensiveDoctrine>
-            <ApproachAngleControl>true</ApproachAngleControl>
-          </InstalledComponent>
-        </MissileSocket>
-        <MissileSocket>
-          <Size>2</Size>
-          <InstalledComponent>
-            <ComponentKey>Stock/Blast Fragmentation</ComponentKey>
-          </InstalledComponent>
-        </MissileSocket>
-        <MissileSocket>
-          <Size>4</Size>
-          <InstalledComponent xsi:type="MissileEngineSettings">
-            <ComponentKey />
-            <BalanceValues>
-              <A>0.565707445</A>
-              <B>0.1086033</B>
-              <C>0.325689256</C>
-            </BalanceValues>
-          </InstalledComponent>
-        </MissileSocket>
-      </Sockets>
-    </MissileTemplate>
-    <MissileTemplate>
-      <Designation>SGM-H-201</Designation>
-      <Nickname>DeathWish</Nickname>
-      <Description>DIRECT - PSV(&lt;color=#53FFFF&gt;EO&lt;/color&gt;) - HEKP</Description>
-      <LongDescription>The SGM-H-201 DeathWish is a size 2 direct guidance missile.  It is based on the SGM-H-2 body, which is a multi-purpose hybrid missile designed to penetrate point defense grids.  This missile will deliver a Delayed Contact Fuze, High Explosive, Kinetic Penetrator warhead.  It homes in on its target using a Passive Electro-Optical seeker.
-
-Control Method: DIRECT
-Targeting Modes:
-	&lt;b&gt;&lt;color=#4CFF72&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
-Primary Seeker: PASSIVE (&lt;color=#53FFFF&gt;EO&lt;/color&gt;)
-
-Cruise: 217 m/s for 14,947 m, top speed in 2.0 s
-Sprint: 667 m/s for 3,389 m, top speed in 0.5 s
-   Stage Trigger at 2,780m from Target
-Terminal Maneuvers: Corkscrew
-
-Delayed Contact Fuze, High Explosive, Kinetic Penetrator
-Penetrator:
-   Armor: 233 cm
-   Component: 126 hp
-Explosive:
-   Component: 1,280 hp
-
-Body Integrity: 25 
-Programming Time: 10 s
-Radar Signature Bonus: 100 %
-Boost-Phase Duration: 3 s
-Boost-Phase Strafe: 100 %
-Boost-Phase Turn Rate: 100 %
-Failure Rate: 0 %</LongDescription>
-      <Cost>26</Cost>
-      <BodyKey>Stock/SGM-H-2 Body</BodyKey>
-      <TemplateKey>59408455-065d-4005-b0a8-cb6bccecc6c3</TemplateKey>
-      <BaseColor>
-        <r>1</r>
-        <g>1</g>
-        <b>1</b>
-        <a>1</a>
-      </BaseColor>
-      <StripeColor>
-        <r>0.129411772</r>
-        <g>0.6313726</g>
-        <b>0.7058824</b>
-        <a>1</a>
-      </StripeColor>
-      <Sockets>
-        <MissileSocket>
-          <Size>1</Size>
-          <InstalledComponent xsi:type="PassiveSeekerSettings">
-            <ComponentKey>Stock/Electro-Optical Seeker</ComponentKey>
-            <Mode>Targeting</Mode>
-            <RejectUnvalidated>false</RejectUnvalidated>
-            <DetectPDTargets>false</DetectPDTargets>
-          </InstalledComponent>
-        </MissileSocket>
-        <MissileSocket>
-          <Size>1</Size>
-        </MissileSocket>
-        <MissileSocket>
-          <Size>1</Size>
-          <InstalledComponent xsi:type="DirectGuidanceSettings">
-            <ComponentKey>Stock/Direct Guidance</ComponentKey>
-            <Role>Offensive</Role>
-            <HotLaunch>false</HotLaunch>
-            <SelfDestructOnLost>false</SelfDestructOnLost>
-            <Maneuvers>Corkscrew</Maneuvers>
-            <DefensiveDoctrine>
-              <TargetSizeMask>12</TargetSizeMask>
-              <TargetSizeOrdering>Descending</TargetSizeOrdering>
-              <SalvoSize>0</SalvoSize>
-              <FarthestFirst>false</FarthestFirst>
-            </DefensiveDoctrine>
-            <ApproachAngleControl>true</ApproachAngleControl>
-          </InstalledComponent>
-        </MissileSocket>
-        <MissileSocket>
-          <Size>4</Size>
-          <InstalledComponent>
-            <ComponentKey>Stock/HE Kinetic Penetrator</ComponentKey>
-          </InstalledComponent>
-        </MissileSocket>
-        <MissileSocket>
-          <Size>4</Size>
-          <InstalledComponent xsi:type="MissileEngineSettings">
-            <ComponentKey />
-            <BalanceValues>
-              <A>0.33333</A>
-              <B>0.33333</B>
-              <C>0.33333</C>
-            </BalanceValues>
-          </InstalledComponent>
-        </MissileSocket>
-        <MissileSocket>
-          <Size>1</Size>
-          <InstalledComponent xsi:type="MissileEngineSettings">
-            <ComponentKey />
-            <BalanceValues>
-              <A>0.33333</A>
-              <B>0.33333</B>
-              <C>0.33333</C>
+              <A>0.3300649</A>
+              <B>0.5217163</B>
+              <C>0.148218811</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>

--- a/data/fleets/TF Sycamore.fleet
+++ b/data/fleets/TF Sycamore.fleet
@@ -6,14 +6,14 @@
   <FactionKey>Stock/Alliance</FactionKey>
   <Description>Difficulty: &lt;color=red&gt;HARD&lt;/color&gt;
 
-This group is comprised of small but deadly ships.  It is heavily missile focused, with every missile type represented in some way and a variety of seeker configurations.  It is highly recommended to explore this fleet and its missiles in the editor to understand its capabilities before taking it into battle.</Description>
+This group is comprised of small but deadly ships. It is heavily missile focused, with every missile type represented in some way with a variety of seeker configurations. It is highly recommended to explore this fleet and its missiles in the editor to understand its capabilities before taking it into battle.</Description>
   <SortOverrideOrder>7</SortOverrideOrder>
   <Ships>
     <Ship>
       <SaveID xsi:nil="true" />
       <Key>93ddee0c-3096-4bfa-b8ec-a5c0dffa02ed</Key>
       <Name>Eye of Providence</Name>
-      <Cost>824</Cost>
+      <Cost>837</Cost>
       <Callsign />
       <Number>660</Number>
       <SymbolOption>1</SymbolOption>
@@ -27,22 +27,22 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
               <MagSaveData>
                 <MagazineKey>79znoH0Lo0KF6s0aIH0U5g</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-160 Rampart</MunitionKey>
-                <Quantity>26</Quantity>
+                <Quantity>27</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>g2nLB74zkUGMg7Iqgad3Qg</MagazineKey>
                 <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>8</Quantity>
+                <Quantity>9</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>ViPKNp7ZhkW7oMONAgFTRw</MagazineKey>
                 <MunitionKey>Stock/EA20 Flare Decoy</MunitionKey>
-                <Quantity>6</Quantity>
+                <Quantity>4</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>61oPMNjTz0OM5msWP0cwqw</MagazineKey>
                 <MunitionKey>Stock/EA99 Active Decoy</MunitionKey>
-                <Quantity>6</Quantity>
+                <Quantity>4</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
@@ -59,12 +59,12 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
               <MagSaveData>
                 <MagazineKey>Vho5BaGVv0uxN6cCUfTAAg</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-H-280 Vortex</MunitionKey>
-                <Quantity>4</Quantity>
+                <Quantity>6</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>CrQ06lRapE-ePIdV5wmkdw</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-210 Thundercloud</MunitionKey>
-                <Quantity>20</Quantity>
+                <Quantity>18</Quantity>
               </MagSaveData>
             </MissileLoad>
             <ConfiguredSize>
@@ -81,12 +81,12 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
               <MagSaveData>
                 <MagazineKey>NjCBPa4pxU-Lk1NTgGDSKw</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-H-280 Vortex</MunitionKey>
-                <Quantity>4</Quantity>
+                <Quantity>6</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>_nIvZhGvCUmx8-6uwSSgFg</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-210 Thundercloud</MunitionKey>
-                <Quantity>20</Quantity>
+                <Quantity>18</Quantity>
               </MagSaveData>
             </MissileLoad>
             <ConfiguredSize>
@@ -143,7 +143,7 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
       <SaveID xsi:nil="true" />
       <Key>8e84cd8d-f17d-4d84-b771-181c5fd0b576</Key>
       <Name>Rod of Iron</Name>
-      <Cost>847</Cost>
+      <Cost>864</Cost>
       <Callsign />
       <Number>970</Number>
       <SymbolOption>0</SymbolOption>
@@ -160,21 +160,29 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
                 <Quantity>11</Quantity>
               </MagSaveData>
               <MagSaveData>
-                <MagazineKey>1aALcNS7AU6-R3wvMBacPQ</MagazineKey>
-                <MunitionKey>Stock/EA20 Flare Decoy</MunitionKey>
-                <Quantity>2</Quantity>
-              </MagSaveData>
-              <MagSaveData>
                 <MagazineKey>PeNfNqFqo060vkEVux44dA</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-160 Rampart</MunitionKey>
-                <Quantity>21</Quantity>
+                <Quantity>12</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>WwMGqYiU7E6lp7ID47phqA</Key>
-          <ComponentName>Stock/E55 'Spotlight' Illuminator</ComponentName>
+          <ComponentName>Stock/VLS-3 Launcher</ComponentName>
+          <ComponentData xsi:type="ResizableCellLauncherData">
+            <MissileLoad>
+              <MagSaveData>
+                <MagazineKey>ZUMtYL1mb0-sbIcfk6xyWw</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-H-360 Shipwreck Block II</MunitionKey>
+                <Quantity>4</Quantity>
+              </MagSaveData>
+            </MissileLoad>
+            <ConfiguredSize>
+              <x>1</x>
+              <y>2</y>
+            </ConfiguredSize>
+          </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>gkfIwYzn7kGhG6MW9uxBmw</Key>
@@ -184,7 +192,12 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
               <MagSaveData>
                 <MagazineKey>FFGkUSfD-EmTdSR-exhULQ</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-H-360 Shipwreck</MunitionKey>
-                <Quantity>6</Quantity>
+                <Quantity>4</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>I530jpzHVkWqyDrOthYuLQ</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-H-360 Shipwreck Block II</MunitionKey>
+                <Quantity>2</Quantity>
               </MagSaveData>
             </MissileLoad>
             <ConfiguredSize>
@@ -201,7 +214,12 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
               <MagSaveData>
                 <MagazineKey>JmlUTubMFkOfsDhXdi84yQ</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-H-360 Shipwreck</MunitionKey>
-                <Quantity>6</Quantity>
+                <Quantity>4</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>rNlMamNxwUO8tGIzcMOYHQ</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-H-360 Shipwreck Block II</MunitionKey>
+                <Quantity>2</Quantity>
               </MagSaveData>
             </MissileLoad>
             <ConfiguredSize>
@@ -261,7 +279,7 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
       <SaveID xsi:nil="true" />
       <Key>bd1cc2e8-735c-4794-bae2-88bbb6cfb8ce</Key>
       <Name>Black Flanks</Name>
-      <Cost>439</Cost>
+      <Cost>464</Cost>
       <Callsign />
       <Number>475</Number>
       <SymbolOption>0</SymbolOption>
@@ -273,7 +291,7 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
           <ComponentData xsi:type="ResizableCellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>k8CZD_jf-E2gEmHmAS9eaA</MagazineKey>
+                <MagazineKey>3MSpTb8qEUurZKClXxJJ6Q</MagazineKey>
                 <MunitionKey>$MODMIS$/SGT-340 Gravestone Block II</MunitionKey>
                 <Quantity>6</Quantity>
               </MagSaveData>
@@ -324,6 +342,10 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
           <ComponentName>Stock/FM230 'Whiplash' Drive</ComponentName>
         </HullSocket>
         <HullSocket>
+          <Key>TSPPW9ECe06-MGzR1i0WvQ</Key>
+          <ComponentName>Stock/Actively Cooled Amplifiers</ComponentName>
+        </HullSocket>
+        <HullSocket>
           <Key>MBOvGazj6UWpt2OOy44s7w</Key>
           <ComponentName>Stock/Missile Programming Bus</ComponentName>
         </HullSocket>
@@ -342,7 +364,7 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
       <SaveID xsi:nil="true" />
       <Key>e9464b37-fe25-4f22-b80f-6cfbaf7ac5ab</Key>
       <Name>Charger</Name>
-      <Cost>466</Cost>
+      <Cost>441</Cost>
       <Callsign />
       <Number>773</Number>
       <SymbolOption>0</SymbolOption>
@@ -354,7 +376,7 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
           <ComponentData xsi:type="ResizableCellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>k8CZD_jf-E2gEmHmAS9eaA</MagazineKey>
+                <MagazineKey>ulAQmEcvNEKMLi7rPMlAyA</MagazineKey>
                 <MunitionKey>$MODMIS$/SGT-340 Gravestone Block II</MunitionKey>
                 <Quantity>6</Quantity>
               </MagSaveData>
@@ -373,7 +395,7 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
               <MagSaveData>
                 <MagazineKey>mlYKQ3ivm0OqiTNLi7Udhw</MagazineKey>
                 <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>9</Quantity>
+                <Quantity>6</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>r83t4oo-bkGknogkxOwLiQ</MagazineKey>
@@ -381,14 +403,9 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
                 <Quantity>2</Quantity>
               </MagSaveData>
               <MagSaveData>
-                <MagazineKey>RNRVA62N4kSwL04kRie6ow</MagazineKey>
-                <MunitionKey>Stock/EA99 Active Decoy</MunitionKey>
-                <Quantity>3</Quantity>
-              </MagSaveData>
-              <MagSaveData>
                 <MagazineKey>8GAgdxOQMESaVv2hrQ_jXg</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-160 Rampart</MunitionKey>
-                <Quantity>27</Quantity>
+                <Quantity>22</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
@@ -430,7 +447,13 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
           <ComponentName>Stock/Missile Programming Bus</ComponentName>
         </HullSocket>
       </SocketMap>
-      <WeaponGroups />
+      <WeaponGroups>
+        <WepGroup Name="Blankets">
+          <MemberKeys>
+            <string>IUdNSVZm2Eu9n3F5HnSAng</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
       <InitialFormation>
         <GuideKey>bd1cc2e8-735c-4794-bae2-88bbb6cfb8ce</GuideKey>
         <RelativePosition>
@@ -445,7 +468,7 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
       <SaveID xsi:nil="true" />
       <Key>a0a020de-ee0a-4108-a837-f8c88967bf1e</Key>
       <Name>Harrier</Name>
-      <Cost>424</Cost>
+      <Cost>394</Cost>
       <Callsign />
       <Number>1277</Number>
       <SymbolOption>0</SymbolOption>
@@ -457,7 +480,7 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
           <ComponentData xsi:type="ResizableCellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>k8CZD_jf-E2gEmHmAS9eaA</MagazineKey>
+                <MagazineKey>w06XzT9lNE6c9jj_D65vdQ</MagazineKey>
                 <MunitionKey>$MODMIS$/SGT-340 Gravestone Block II</MunitionKey>
                 <Quantity>6</Quantity>
               </MagSaveData>
@@ -478,7 +501,7 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
         </HullSocket>
         <HullSocket>
           <Key>ZxY9ONYz80SiLNSObvjNzQ</Key>
-          <ComponentName>Stock/E71 'Hangup' Jammer</ComponentName>
+          <ComponentName>Stock/E55 'Spotlight' Illuminator</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>XPaYCjBqdEqBxEIsVLP0oA</Key>
@@ -518,7 +541,7 @@ This group is comprised of small but deadly ships.  It is heavily missile focuse
             <string>IUdNSVZm2Eu9n3F5HnSAng</string>
           </MemberKeys>
         </WepGroup>
-        <WepGroup Name="Hangups">
+        <WepGroup Name="Spotlight">
           <MemberKeys>
             <string>ZxY9ONYz80SiLNSObvjNzQ</string>
           </MemberKeys>
@@ -547,15 +570,16 @@ Targeting Modes:
 	&lt;b&gt;&lt;color=#FF2525&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
 Primary Seeker: COMMAND (&lt;color=#FBFF4C&gt;Requires COMMS Enabled&lt;/color&gt;)
 
-148 m/s for 7,102 m, top speed in 1.2 s
+185 m/s for 4,502 m, top speed in 1.0 s
 Terminal Maneuvers: Corkscrew
 
 Contact Fuze, High Explosive, Shaped
-Armor: 123cm   Component: 5,040hp
+Armor: 104cm   Component: 3,600hp
 Blast Angle: 70 deg
+Damage Per Fragment: 50.0
 
-Body Integrity: 110 
-Programming Time: 6 s
+Body Integrity: 160 
+Programming Time: 3 s
 Radar Signature Bonus: 100 %
 Boost-Phase Duration: 3 s
 Boost-Phase Strafe: 250 % (&lt;color=#4CFF72&gt;+150%&lt;/color&gt;)
@@ -565,15 +589,15 @@ Failure Rate: 0 %</LongDescription>
       <BodyKey>Stock/SGT-3 Body</BodyKey>
       <TemplateKey>295340de-e2d8-475c-b10c-d8d8a5baa1a0</TemplateKey>
       <BaseColor>
-        <r>0.2627451</r>
-        <g>0.2627451</g>
-        <b>0.2627451</b>
+        <r>0.8269358</r>
+        <g>0.0153443245</g>
+        <b>0.0153443245</b>
         <a>1</a>
       </BaseColor>
       <StripeColor>
-        <r>0.0486429669</r>
-        <g>0.551552832</g>
-        <b>0.394533783</b>
+        <r>0.9999999</r>
+        <g>0.9802647</g>
+        <b>0.005894362</b>
         <a>1</a>
       </StripeColor>
       <Sockets>
@@ -601,27 +625,28 @@ Failure Rate: 0 %</LongDescription>
             <Maneuvers>Corkscrew</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
             </DefensiveDoctrine>
-            <ApproachAngleControl>true</ApproachAngleControl>
+            <ApproachAngleControl>false</ApproachAngleControl>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>7</Size>
+          <Size>5</Size>
           <InstalledComponent>
             <ComponentKey>Stock/HE Impact</ComponentKey>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>7</Size>
+          <Size>9</Size>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.308009863</A>
-              <B>0.281300247</B>
-              <C>0.4106899</C>
+              <A>0.08347691</A>
+              <B>0.500385761</B>
+              <C>0.416137338</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>
@@ -638,12 +663,12 @@ Targeting Modes:
 	&lt;b&gt;&lt;color=#4CFF72&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
 Primary Seeker: ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
 
-300 m/s for 4,707 m, top speed in 0.6 s
+270 m/s for 5,023 m, top speed in 0.7 s
 Terminal Maneuvers: None
 
 Proximity Fuze, High Explosive, Blast Fragmentation
-Armor: 1cm   Component: 40hp
-Blast Radius: 33 m
+Armor: 2cm   Component: 65hp
+Blast Radius: 47 m
 
 Body Integrity: 10 
 Programming Time: 6 s
@@ -671,10 +696,10 @@ Failure Rate: 0 %</LongDescription>
         <MissileSocket>
           <Size>1</Size>
           <InstalledComponent xsi:type="ActiveSeekerSettings">
-            <ComponentKey>Stock/Fixed Active Radar Seeker</ComponentKey>
+            <ComponentKey>Stock/Steerable Active Radar Seeker</ComponentKey>
             <Mode>Targeting</Mode>
             <RejectUnvalidated>false</RejectUnvalidated>
-            <DetectPDTargets>true</DetectPDTargets>
+            <DetectPDTargets>false</DetectPDTargets>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
@@ -682,32 +707,33 @@ Failure Rate: 0 %</LongDescription>
           <InstalledComponent xsi:type="DirectGuidanceSettings">
             <ComponentKey>Stock/Direct Guidance</ComponentKey>
             <Role>Defensive</Role>
-            <HotLaunch>false</HotLaunch>
+            <HotLaunch>true</HotLaunch>
             <SelfDestructOnLost>false</SelfDestructOnLost>
             <Maneuvers>None</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
-              <SalvoSize>0</SalvoSize>
+              <SalvoSize>1</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
             </DefensiveDoctrine>
             <ApproachAngleControl>true</ApproachAngleControl>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>2</Size>
+          <Size>4</Size>
           <InstalledComponent>
             <ComponentKey>Stock/Blast Fragmentation</ComponentKey>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>4</Size>
+          <Size>3</Size>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.333333343</A>
-              <B>0.333333343</B>
-              <C>0.333333343</C>
+              <A>0.134217873</A>
+              <B>0.7181097</B>
+              <C>0.1476724</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>
@@ -726,13 +752,14 @@ Primary Seeker: SEMI-ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
 Validation Seeker(s): PASSIVE (&lt;color=#53FFFF&gt;EO&lt;/color&gt;)
 
 Cruise: 200 m/s for 15,667 m, top speed in 3.3 s
-Sprint: 838 m/s for 4,531 m, top speed in 1.0 s
+Sprint: 791 m/s for 4,728 m, top speed in 0.9 s
    Stage Trigger on Target Detection (&lt;color=#FBFF4C&gt;Direction-Only Seeker&lt;/color&gt;)
 Terminal Maneuvers: Weave
 
 Contact Fuze, High Explosive, Shaped
 Armor: 80cm   Component: 2,160hp
 Blast Angle: 70 deg
+Damage Per Fragment: 50.0
 
 Body Integrity: 60 
 Programming Time: 16 s
@@ -741,7 +768,7 @@ Boost-Phase Duration: 3 s
 Boost-Phase Strafe: 100 %
 Boost-Phase Turn Rate: 100 %
 Failure Rate: 0 %</LongDescription>
-      <Cost>36</Cost>
+      <Cost>23</Cost>
       <BodyKey>Stock/SGM-H-3 Body</BodyKey>
       <TemplateKey>d64a2477-f089-49f3-b7bc-719d21ee3b97</TemplateKey>
       <BaseColor>
@@ -777,9 +804,6 @@ Failure Rate: 0 %</LongDescription>
         </MissileSocket>
         <MissileSocket>
           <Size>1</Size>
-          <InstalledComponent>
-            <ComponentKey>Stock/Decoy Launcher</ComponentKey>
-          </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
           <Size>1</Size>
@@ -791,6 +815,7 @@ Failure Rate: 0 %</LongDescription>
             <Maneuvers>Weave</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
@@ -808,9 +833,9 @@ Failure Rate: 0 %</LongDescription>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.640891433</A>
-              <B>0.173926115</B>
-              <C>0.185182452</C>
+              <A>0.535071552</A>
+              <B>0.230021164</B>
+              <C>0.234907284</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>
@@ -839,14 +864,15 @@ Targeting Modes:
 Primary Seeker: SEMI-ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
 Validation Seeker(s): PASSIVE (&lt;color=#FF2525&gt;WAKE&lt;/color&gt;)
 
-Cruise: 285 m/s for 12,117 m, top speed in 2.8 s
-Sprint: 770 m/s for 4,493 m, top speed in 0.8 s
+Cruise: 285 m/s for 16,166 m, top speed in 3.2 s
+Sprint: 603 m/s for 4,500 m, top speed in 0.6 s
    Stage Trigger on Target Detection (&lt;color=#FBFF4C&gt;Direction-Only Seeker&lt;/color&gt;)
 Terminal Maneuvers: Weave
 
 Contact Fuze, High Explosive, Shaped
-Armor: 48cm   Component: 768hp
+Armor: 54cm   Component: 960hp
 Blast Angle: 70 deg
+Damage Per Fragment: 50.0
 
 Body Integrity: 25 
 Programming Time: 10 s
@@ -855,19 +881,19 @@ Boost-Phase Duration: 3 s
 Boost-Phase Strafe: 100 %
 Boost-Phase Turn Rate: 100 %
 Failure Rate: 0 %</LongDescription>
-      <Cost>13</Cost>
+      <Cost>11</Cost>
       <BodyKey>Stock/SGM-H-2 Body</BodyKey>
       <TemplateKey>3ca37f6e-588b-4d9b-94e3-7cfa4f61d274</TemplateKey>
       <BaseColor>
-        <r>1</r>
-        <g>1</g>
-        <b>1</b>
+        <r>0.0107289571</r>
+        <g>0.01742046</g>
+        <b>0.244516492</b>
         <a>1</a>
       </BaseColor>
       <StripeColor>
-        <r>0.129411772</r>
-        <g>0.6313726</g>
-        <b>0.7058824</b>
+        <r>0.0713833</r>
+        <g>0.6686697</g>
+        <b>0.0314566046</b>
         <a>1</a>
       </StripeColor>
       <Sockets>
@@ -876,7 +902,7 @@ Failure Rate: 0 %</LongDescription>
           <InstalledComponent xsi:type="ActiveSeekerSettings">
             <ComponentKey>Stock/Fixed Semi-Active Radar Seeker</ComponentKey>
             <Mode>Targeting</Mode>
-            <RejectUnvalidated>true</RejectUnvalidated>
+            <RejectUnvalidated>false</RejectUnvalidated>
             <DetectPDTargets>false</DetectPDTargets>
           </InstalledComponent>
         </MissileSocket>
@@ -899,6 +925,7 @@ Failure Rate: 0 %</LongDescription>
             <Maneuvers>Weave</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
@@ -907,18 +934,18 @@ Failure Rate: 0 %</LongDescription>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>4</Size>
+          <Size>5</Size>
           <InstalledComponent>
             <ComponentKey>Stock/HE Impact</ComponentKey>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>4</Size>
+          <Size>3</Size>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.5401372</A>
-              <B>0.459862828</B>
+              <A>0.205962837</A>
+              <B>0.794037163</B>
               <C>0</C>
             </BalanceValues>
           </InstalledComponent>
@@ -929,8 +956,8 @@ Failure Rate: 0 %</LongDescription>
             <ComponentKey />
             <BalanceValues>
               <A>0.6725945</A>
-              <B>0.0441603065</B>
-              <C>0.2832452</C>
+              <B>0.20448412</B>
+              <C>0.122921392</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>
@@ -948,12 +975,13 @@ Targeting Modes:
 Primary Seeker: SEMI-ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
 Backup Seeker(s): HOME-ON-JAM (&lt;color=#4CFF72&gt;RADAR&lt;/color&gt; JAMMING Signals Only)
 
-252 m/s for 10,114 m, top speed in 1.4 s
+253 m/s for 10,017 m, top speed in 1.4 s
 Terminal Maneuvers: Weave
 
 Contact Fuze, High Explosive, Shaped
 Armor: 60cm   Component: 1,200hp
 Blast Angle: 70 deg
+Damage Per Fragment: 50.0
 
 Body Integrity: 30 
 Programming Time: 8 s
@@ -1006,6 +1034,7 @@ Failure Rate: 0 %</LongDescription>
             <Maneuvers>Weave</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
@@ -1024,9 +1053,125 @@ Failure Rate: 0 %</LongDescription>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.5087956</A>
-              <B>0.2610692</B>
-              <C>0.230135173</C>
+              <A>0.5140794</A>
+              <B>0.254208267</B>
+              <C>0.231712341</C>
+            </BalanceValues>
+          </InstalledComponent>
+        </MissileSocket>
+      </Sockets>
+    </MissileTemplate>
+    <MissileTemplate>
+      <Designation>SGM-H-360</Designation>
+      <Nickname>Shipwreck Block II</Nickname>
+      <Description>CRUISE - SAH(&lt;color=#4CFF72&gt;RADAR&lt;/color&gt;)/[PSV(&lt;color=#53FFFF&gt;EO&lt;/color&gt;)] - HE SHAPED</Description>
+      <LongDescription>The SGM-H-360 Shipwreck Block II is a size 3 waypoint-capable cruise missile.  It is based on the SGM-H-3 body, which is a high speed hybrid missile designed to strike heavy targets.  This missile will deliver a Contact Fuze, High Explosive, Shaped warhead.  It homes in on its target using a Semi-Active Radar seeker, validating that it is the correct target using a Passive Electro-Optical seeker.
+
+Control Method: CRUISE (Waypoint Capable)
+Targeting Modes:
+	&lt;b&gt;&lt;color=#4CFF72&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK[+TRP]&lt;/color&gt;&lt;/b&gt;
+Primary Seeker: SEMI-ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
+Validation Seeker(s): PASSIVE (&lt;color=#53FFFF&gt;EO&lt;/color&gt;)
+
+Cruise: 200 m/s for 15,667 m, top speed in 3.3 s
+Sprint: 791 m/s for 4,699 m, top speed in 0.9 s
+   Stage Trigger on Target Detection (&lt;color=#FBFF4C&gt;Direction-Only Seeker&lt;/color&gt;)
+Terminal Maneuvers: Weave
+
+Contact Fuze, High Explosive, Shaped
+Armor: 80cm   Component: 2,160hp
+Blast Angle: 70 deg
+Damage Per Fragment: 50.0
+
+Body Integrity: 60 
+Programming Time: 16 s
+Radar Signature Bonus: 100 %
+Boost-Phase Duration: 3 s
+Boost-Phase Strafe: 100 %
+Boost-Phase Turn Rate: 100 %
+Failure Rate: 0 %</LongDescription>
+      <Cost>35</Cost>
+      <BodyKey>Stock/SGM-H-3 Body</BodyKey>
+      <TemplateKey>4852f21a-7ef9-41fd-8891-4a8548d9a033</TemplateKey>
+      <BaseColor>
+        <r>1</r>
+        <g>1</g>
+        <b>1</b>
+        <a>1</a>
+      </BaseColor>
+      <StripeColor>
+        <r>0.117647059</r>
+        <g>0.6313726</g>
+        <b>0.192156866</b>
+        <a>1</a>
+      </StripeColor>
+      <Sockets>
+        <MissileSocket>
+          <Size>1</Size>
+          <InstalledComponent xsi:type="ActiveSeekerSettings">
+            <ComponentKey>Stock/Fixed Semi-Active Radar Seeker</ComponentKey>
+            <Mode>Targeting</Mode>
+            <RejectUnvalidated>true</RejectUnvalidated>
+            <DetectPDTargets>false</DetectPDTargets>
+          </InstalledComponent>
+        </MissileSocket>
+        <MissileSocket>
+          <Size>1</Size>
+          <InstalledComponent xsi:type="PassiveSeekerSettings">
+            <ComponentKey>Stock/Electro-Optical Seeker</ComponentKey>
+            <Mode>Validation</Mode>
+            <RejectUnvalidated>false</RejectUnvalidated>
+            <DetectPDTargets>false</DetectPDTargets>
+          </InstalledComponent>
+        </MissileSocket>
+        <MissileSocket>
+          <Size>1</Size>
+          <InstalledComponent>
+            <ComponentKey>Stock/Decoy Launcher</ComponentKey>
+          </InstalledComponent>
+        </MissileSocket>
+        <MissileSocket>
+          <Size>1</Size>
+          <InstalledComponent xsi:type="CruiseGuidanceSettings">
+            <ComponentKey>Stock/Cruise Guidance</ComponentKey>
+            <Role>Offensive</Role>
+            <HotLaunch>false</HotLaunch>
+            <SelfDestructOnLost>false</SelfDestructOnLost>
+            <Maneuvers>Weave</Maneuvers>
+            <DefensiveDoctrine>
+              <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
+              <TargetSizeOrdering>Descending</TargetSizeOrdering>
+              <SalvoSize>0</SalvoSize>
+              <FarthestFirst>false</FarthestFirst>
+            </DefensiveDoctrine>
+          </InstalledComponent>
+        </MissileSocket>
+        <MissileSocket>
+          <Size>5</Size>
+          <InstalledComponent>
+            <ComponentKey>Stock/HE Impact</ComponentKey>
+          </InstalledComponent>
+        </MissileSocket>
+        <MissileSocket>
+          <Size>5</Size>
+          <InstalledComponent xsi:type="MissileEngineSettings">
+            <ComponentKey />
+            <BalanceValues>
+              <A>0.535071552</A>
+              <B>0.2259696</B>
+              <C>0.238958851</C>
+            </BalanceValues>
+          </InstalledComponent>
+        </MissileSocket>
+        <MissileSocket>
+          <Size>1</Size>
+          <InstalledComponent xsi:type="MissileEngineSettings">
+            <ComponentKey />
+            <BalanceValues>
+              <A>1</A>
+              <B>0</B>
+              <C>0</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>

--- a/data/fleets/TF Willow.fleet
+++ b/data/fleets/TF Willow.fleet
@@ -6,14 +6,14 @@
   <FactionKey>Stock/Alliance</FactionKey>
   <Description>Difficulty: &lt;color=yellow&gt;MODERATE&lt;/color&gt;
 
-A combined arms fleet with a railgun heavy cruiser for fire support, two semi-active missile frigates, and a beam destroyer.  This fleet allows you to keep your options open and spread your forces out to take on different challenges.  But be warned: combined arms fleets require significant multitasking to be successful.</Description>
+A combined arms fleet with a mixed cannon/beam heavy cruiser for the frontline, along with an electronic warfare frigate, missile frigate, and rail destroyer. This fleet allows you to keep your options open and spread your forces out to take on different challenges. But be warned: combined arms fleets require significant multitasking to be successful.</Description>
   <SortOverrideOrder>4</SortOverrideOrder>
   <Ships>
     <Ship>
       <SaveID xsi:nil="true" />
       <Key>16f1a4b6-d754-4060-aaae-21864ca19ec1</Key>
       <Name>Conclusion Absolute</Name>
-      <Cost>1607</Cost>
+      <Cost>1585</Cost>
       <Callsign />
       <Number>537</Number>
       <SymbolOption>0</SymbolOption>
@@ -21,28 +21,19 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
       <SocketMap>
         <HullSocket>
           <Key>whDP9rtbukKsocnrqnqaLQ</Key>
-          <ComponentName>Stock/Mk81 Railgun</ComponentName>
+          <ComponentName>Stock/Mk66 Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>8CtCKPLfZEOOFvm1DhV-oQ</Key>
-          <ComponentName>Stock/VLS-1-46 Launcher</ComponentName>
-          <ComponentData xsi:type="CellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>f6ol2bK37kO1FZn3rITt0A</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>46</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-          </ComponentData>
+          <ComponentName>Stock/Mk66 Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>N7yRYYUuG0uOzd5aufgViA</Key>
-          <ComponentName>Stock/Mk81 Railgun</ComponentName>
+          <ComponentName>Stock/Mk610 Beam Turret</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>lYEQo4jJvEGxRqJa2MB25A</Key>
-          <ComponentName>Stock/E90 'Blanket' Jammer</ComponentName>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>9qreGP2Iw0KwuloNpNFTSg</Key>
@@ -50,7 +41,7 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
         </HullSocket>
         <HullSocket>
           <Key>v9Sqa5DcCkibdi29AkakNg</Key>
-          <ComponentName>Stock/E90 'Blanket' Jammer</ComponentName>
+          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>3MoeYUx1HUS6xNDBMsssig</Key>
@@ -77,6 +68,10 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
           <ComponentName>Stock/Berthing</ComponentName>
         </HullSocket>
         <HullSocket>
+          <Key>TX2TktZe7EWB9s-MqlDQgA</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
           <Key>cMs0g0g3WUeZJQASb7omew</Key>
           <ComponentName>Stock/Plant Control Center</ComponentName>
         </HullSocket>
@@ -86,14 +81,24 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
           <ComponentData xsi:type="BulkMagazineData">
             <Load>
               <MagSaveData>
-                <MagazineKey>kvKUA2xFRE29kQaQoerWIw</MagazineKey>
-                <MunitionKey>Stock/300mm AP Rail Sabot</MunitionKey>
-                <Quantity>350</Quantity>
-              </MagSaveData>
-              <MagSaveData>
                 <MagazineKey>ztRjSrmj9kaIXtxNj6vlnw</MagazineKey>
                 <MunitionKey>Stock/Flak Round</MunitionKey>
-                <Quantity>2000</Quantity>
+                <Quantity>900</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>AShuCeOCUEevWqTx1aivMw</MagazineKey>
+                <MunitionKey>Stock/450mm HE Shell</MunitionKey>
+                <Quantity>300</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>By6J2Z_gA0e78bcWsaViNw</MagazineKey>
+                <MunitionKey>Stock/450mm AP Shell</MunitionKey>
+                <Quantity>200</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>AwgADSUo40Wx9HMN2VDhdw</MagazineKey>
+                <MunitionKey>Stock/20mm Slug</MunitionKey>
+                <Quantity>16000</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
@@ -104,19 +109,23 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
         </HullSocket>
         <HullSocket>
           <Key>SV_4BgcxwU24YIbep-k74g</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>A8e_Z_d8WU2qzo6HTQwCBA</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>2xmOS4ns_EaMYjBXrrhhig</Key>
-          <ComponentName>Stock/Basic CIC</ComponentName>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>y1xLixKUzUSKT7Nz7aUkLQ</Key>
           <ComponentName>Stock/Damage Control Central</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>RmUeePb-8EGbFaRgVjCXsA</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>eYp1IPfupUGVITrkVhgZJw</Key>
@@ -144,7 +153,7 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
         </HullSocket>
         <HullSocket>
           <Key>oyAxfnepkEG46VjtvQWXpw</Key>
-          <ComponentName>Stock/Energy Regulator</ComponentName>
+          <ComponentName>Stock/Focused Particle Accelerator</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>Yo9hPw6Mf060B3vqwSO4GA</Key>
@@ -152,36 +161,35 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
         </HullSocket>
         <HullSocket>
           <Key>CgpRQa-660KEed1wTRL4vw</Key>
-          <ComponentName>Stock/Mount Gyros</ComponentName>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>awwdeDnNs0G-RceQF1TByA</Key>
-          <ComponentName>Stock/Mount Gyros</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>tnZD-B5Ls0qAyBtdz4yoTA</Key>
-          <ComponentName>Stock/Adaptive Radar Receiver</ComponentName>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>S8ALcpOMYEqJog1v2q8UMQ</Key>
-          <ComponentName>Stock/RS35 'Frontline' Radar</ComponentName>
+          <ComponentName>Stock/RM50 'Parallax' Radar</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>rQWETsDGdE-AR8N3NPfwXg</Key>
-          <ComponentName>Stock/Mount Gyros</ComponentName>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
         </HullSocket>
       </SocketMap>
       <WeaponGroups>
-        <WepGroup Name="Railguns">
+        <WepGroup Name="Front Gun">
           <MemberKeys>
             <string>whDP9rtbukKsocnrqnqaLQ</string>
-            <string>N7yRYYUuG0uOzd5aufgViA</string>
           </MemberKeys>
         </WepGroup>
-        <WepGroup Name="Jammer">
+        <WepGroup Name="Aft Gun">
           <MemberKeys>
-            <string>lYEQo4jJvEGxRqJa2MB25A</string>
-            <string>v9Sqa5DcCkibdi29AkakNg</string>
+            <string>8CtCKPLfZEOOFvm1DhV-oQ</string>
+          </MemberKeys>
+        </WepGroup>
+        <WepGroup Name="Beam">
+          <MemberKeys>
+            <string>N7yRYYUuG0uOzd5aufgViA</string>
           </MemberKeys>
         </WepGroup>
       </WeaponGroups>
@@ -191,114 +199,9 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
       <SaveID xsi:nil="true" />
       <Key>aff5bd9f-a8e0-4643-8daf-c7b6e15723ab</Key>
       <Name>Word Cadence</Name>
-      <Cost>468</Cost>
-      <Callsign />
-      <Number>614</Number>
-      <SymbolOption>1</SymbolOption>
-      <HullType>Stock/Raines Frigate</HullType>
-      <SocketMap>
-        <HullSocket>
-          <Key>PDKmGfvpykODc3XHDQ7WBw</Key>
-          <ComponentName>Stock/VLS-2 Launcher</ComponentName>
-          <ComponentData xsi:type="ResizableCellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>m3GQVQTKsUawUbJNIgaeCA</MagazineKey>
-                <MunitionKey>$MODMIS$/SGM-233 Gale</MunitionKey>
-                <Quantity>16</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-            <ConfiguredSize>
-              <x>1</x>
-              <y>2</y>
-            </ConfiguredSize>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>WwMGqYiU7E6lp7ID47phqA</Key>
-          <ComponentName>Stock/E55 'Spotlight' Illuminator</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>gkfIwYzn7kGhG6MW9uxBmw</Key>
-          <ComponentName>Stock/VLS-2 Launcher</ComponentName>
-          <ComponentData xsi:type="ResizableCellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>82pv4YTObkSmsFmB3XOXyA</MagazineKey>
-                <MunitionKey>$MODMIS$/SGM-233 Gale</MunitionKey>
-                <Quantity>24</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-            <ConfiguredSize>
-              <x>1</x>
-              <y>3</y>
-            </ConfiguredSize>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>D3zoB0PetEC973iUck_mNQ</Key>
-          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
-          <ComponentData xsi:type="CellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>4Il23BEsy0-H8BvAPzSlpw</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>23</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>98N-YI_1WUOs--qPYlt-7g</Key>
-          <ComponentName>Stock/Basic CIC</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>6Tzo7268MEqgyFxnGvLKUg</Key>
-          <ComponentName>Stock/Plant Control Center</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>O_Y-AJc7r0alOg36rvY6MQ</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>5APOD4UfSkGdkm9WWdAvLA</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>lorATFhkTkeZQYThYOHazg</Key>
-          <ComponentName>Stock/Berthing</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>bRgUlaoQJ0S7M91zMpdAdA</Key>
-          <ComponentName>Stock/FR4800 Reactor</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>Jmtnwo0KQki5QyEPPlBHrA</Key>
-          <ComponentName>Stock/FM200 Drive</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>V42tXibIR0e4u6riIHYZOw</Key>
-          <ComponentName>Stock/RS41 'Spyglass' Radar</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>p-m7ijS6ukuqzuBT5NE_lA</Key>
-          <ComponentName>Stock/Adaptive Radar Receiver</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>foApM84hT0GpEw4GaFv38w</Key>
-          <ComponentName>Stock/Adaptive Radar Receiver</ComponentName>
-        </HullSocket>
-      </SocketMap>
-      <WeaponGroups />
-      <TemplateMissileTypes />
-    </Ship>
-    <Ship>
-      <SaveID xsi:nil="true" />
-      <Key>811a447a-b0bc-47e2-beee-164ab395575d</Key>
-      <Name>The Amber Crash</Name>
       <Cost>470</Cost>
       <Callsign />
-      <Number>126</Number>
+      <Number>614</Number>
       <SymbolOption>1</SymbolOption>
       <HullType>Stock/Raines Frigate</HullType>
       <SocketMap>
@@ -308,9 +211,14 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
           <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>9CWbg7JuZ0io7Ed-qH8HVg</MagazineKey>
+                <MagazineKey>EM-Z4WrrhEy8dO6v_iTaVA</MagazineKey>
                 <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>22</Quantity>
+                <Quantity>13</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>OAv0qlZ2a0edzxB7spptIQ</MagazineKey>
+                <MunitionKey>Stock/EA99 Active Decoy</MunitionKey>
+                <Quantity>6</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
@@ -342,9 +250,9 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
           <ComponentData xsi:type="ResizableCellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>NYtBIoGqDUScXrkGSLy_qg</MagazineKey>
+                <MagazineKey>QXVTjDjJzUeg6qcz2z4Sfw</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-233 Gale</MunitionKey>
-                <Quantity>17</Quantity>
+                <Quantity>24</Quantity>
               </MagSaveData>
             </MissileLoad>
             <ConfiguredSize>
@@ -359,7 +267,81 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
         </HullSocket>
         <HullSocket>
           <Key>6Tzo7268MEqgyFxnGvLKUg</Key>
-          <ComponentName>Stock/Plant Control Center</ComponentName>
+          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load />
+          </ComponentData>
+        </HullSocket>
+        <HullSocket>
+          <Key>O_Y-AJc7r0alOg36rvY6MQ</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>lorATFhkTkeZQYThYOHazg</Key>
+          <ComponentName>Stock/Berthing</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>bRgUlaoQJ0S7M91zMpdAdA</Key>
+          <ComponentName>Stock/FR4800 Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>Jmtnwo0KQki5QyEPPlBHrA</Key>
+          <ComponentName>Stock/FM200 Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>V42tXibIR0e4u6riIHYZOw</Key>
+          <ComponentName>Stock/RS35 'Frontline' Radar</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>foApM84hT0GpEw4GaFv38w</Key>
+          <ComponentName>Stock/Missile Programming Bus Array</ComponentName>
+        </HullSocket>
+      </SocketMap>
+      <WeaponGroups>
+        <WepGroup Name="Target Painter">
+          <MemberKeys>
+            <string>WwMGqYiU7E6lp7ID47phqA</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
+      <TemplateMissileTypes />
+    </Ship>
+    <Ship>
+      <SaveID xsi:nil="true" />
+      <Key>1c4a478b-5582-45bb-85f2-aec5180505f2</Key>
+      <Name>Amber Crash</Name>
+      <Cost>425</Cost>
+      <Callsign />
+      <Number>126</Number>
+      <SymbolOption>2</SymbolOption>
+      <HullType>Stock/Raines Frigate</HullType>
+      <SocketMap>
+        <HullSocket>
+          <Key>PDKmGfvpykODc3XHDQ7WBw</Key>
+          <ComponentName>Stock/E90 'Blanket' Jammer</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>WwMGqYiU7E6lp7ID47phqA</Key>
+          <ComponentName>Stock/E71 'Hangup' Jammer</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gkfIwYzn7kGhG6MW9uxBmw</Key>
+          <ComponentName>Stock/E90 'Blanket' Jammer</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>D3zoB0PetEC973iUck_mNQ</Key>
+          <ComponentName>Stock/E70 'Interruption' Jammer</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>98N-YI_1WUOs--qPYlt-7g</Key>
+          <ComponentName>Stock/Basic CIC</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>6Tzo7268MEqgyFxnGvLKUg</Key>
+          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load />
+          </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>O_Y-AJc7r0alOg36rvY6MQ</Key>
@@ -367,7 +349,7 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
         </HullSocket>
         <HullSocket>
           <Key>5APOD4UfSkGdkm9WWdAvLA</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <ComponentName>Stock/Plant Control Center</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>lorATFhkTkeZQYThYOHazg</Key>
@@ -386,22 +368,40 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
           <ComponentName>Stock/RS41 'Spyglass' Radar</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>p-m7ijS6ukuqzuBT5NE_lA</Key>
-          <ComponentName>Stock/Adaptive Radar Receiver</ComponentName>
-        </HullSocket>
-        <HullSocket>
           <Key>foApM84hT0GpEw4GaFv38w</Key>
-          <ComponentName>Stock/Adaptive Radar Receiver</ComponentName>
+          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
         </HullSocket>
       </SocketMap>
-      <WeaponGroups />
+      <WeaponGroups>
+        <WepGroup Name="Radar 1">
+          <MemberKeys />
+        </WepGroup>
+        <WepGroup Name="Comms">
+          <MemberKeys />
+        </WepGroup>
+        <WepGroup Name="Radar 2">
+          <MemberKeys />
+        </WepGroup>
+        <WepGroup Name="Missile Shield">
+          <MemberKeys>
+            <string>D3zoB0PetEC973iUck_mNQ</string>
+          </MemberKeys>
+        </WepGroup>
+        <WepGroup Name="Jammers">
+          <MemberKeys>
+            <string>PDKmGfvpykODc3XHDQ7WBw</string>
+            <string>WwMGqYiU7E6lp7ID47phqA</string>
+            <string>gkfIwYzn7kGhG6MW9uxBmw</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
       <TemplateMissileTypes />
     </Ship>
     <Ship>
       <SaveID xsi:nil="true" />
       <Key>6987c592-d06a-47df-8dfe-68e9db17d31d</Key>
       <Name>Early Blooming</Name>
-      <Cost>455</Cost>
+      <Cost>520</Cost>
       <Callsign />
       <Number>837</Number>
       <SymbolOption>2</SymbolOption>
@@ -416,29 +416,16 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
           <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>JpOU9MgWXEmfLcQoAK4otA</Key>
-          <ComponentName>Stock/VLS-1-23 Launcher</ComponentName>
-          <ComponentData xsi:type="CellLauncherData">
-            <MissileLoad>
-              <MagSaveData>
-                <MagazineKey>xBwOly-ztEqZcgMnq_Ie6w</MagazineKey>
-                <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>23</Quantity>
-              </MagSaveData>
-            </MissileLoad>
-          </ComponentData>
-        </HullSocket>
-        <HullSocket>
-          <Key>LCosRblddUCjPogeJ5eSeA</Key>
-          <ComponentName>Stock/Mk20 'Defender' PDT</ComponentName>
-        </HullSocket>
-        <HullSocket>
           <Key>hGeid9yk80GqIN5IUlp8aw</Key>
-          <ComponentName>Stock/Mk600 Beam Cannon</ComponentName>
+          <ComponentName>Stock/Mk550 Mass Driver</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>ytRGy84X_kW1odHYCBICDQ</Key>
+          <ComponentName>Stock/Plant Control Center</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>yM3Am4PqyUOIByTKzM6sPA</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <ComponentName>Stock/Basic CIC</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>H1ekC2-9c02VyNXY4IeLYA</Key>
@@ -446,7 +433,7 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
         </HullSocket>
         <HullSocket>
           <Key>ln5c_ZvdCUSMVWZL_-m3yw</Key>
-          <ComponentName>Stock/Reinforced CIC</ComponentName>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>H-oABJbYw0qgKd4QzU0WaA</Key>
@@ -460,7 +447,12 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
               <MagSaveData>
                 <MagazineKey>5RasId42-0qRTG4hjUE31g</MagazineKey>
                 <MunitionKey>Stock/20mm Slug</MunitionKey>
-                <Quantity>14000</Quantity>
+                <Quantity>8000</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>O_EjMvJlEEO2l3RRdQuPQA</MagazineKey>
+                <MunitionKey>Stock/300mm AP Rail Sabot</MunitionKey>
+                <Quantity>150</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
@@ -474,12 +466,24 @@ A combined arms fleet with a railgun heavy cruiser for fire support, two semi-ac
           <ComponentName>Stock/FM200 Drive</ComponentName>
         </HullSocket>
         <HullSocket>
+          <Key>m5J1jQdOfUKM9r7NZjMpKA</Key>
+          <ComponentName>Stock/Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
           <Key>h29TSNGRo0m_DmeRr2BqDw</Key>
-          <ComponentName>Stock/FR3300 Micro Reactor</ComponentName>
+          <ComponentName>Stock/Energy Regulator</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>E9sMCEquVk-NNj5heGmIlQ</Key>
           <ComponentName>Stock/RS35 'Frontline' Radar</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>gx2UKetKWUm5BfZhiD5phQ</Key>
+          <ComponentName>Stock/Small Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>ZJTmbGdjAk-XEKihIYHEuw</Key>
+          <ComponentName>Stock/Energy Regulator</ComponentName>
         </HullSocket>
       </SocketMap>
       <WeaponGroups />
@@ -505,6 +509,7 @@ Terminal Maneuvers: None
 Contact Fuze, High Explosive, Shaped
 Armor: 54cm   Component: 960hp
 Blast Angle: 70 deg
+Damage Per Fragment: 50.0
 
 Body Integrity: 30 
 Programming Time: 8 s
@@ -551,6 +556,7 @@ Failure Rate: 0 %</LongDescription>
             <Maneuvers>None</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>

--- a/data/fleets/Wulfenite Squadron.fleet
+++ b/data/fleets/Wulfenite Squadron.fleet
@@ -6,15 +6,16 @@
   <FactionKey>Stock/Protectorate</FactionKey>
   <Description>Difficulty: &lt;color=yellow&gt;MODERATE&lt;/color&gt;
 
-This squadron is built around a steadfast capital ship with a supporting utility vessel and flight of rocket shuttles. The cruiser's imposing presence and the feeder's decoys work to distract and displace enemy forces, providing openings for the shuttles to move in and release devastating rocket barrages. Beware, the feeder and shuttles are vulnerable to direct fire and missile strikes. Keep them in cover or stay within range of the cruiser's defenses.</Description>
+Wulfenite Squadron is built around a steadfast capital ship with a supporting missile monitor and flight of rocket shuttles. The cruiser's imposing presence and the monitor's container salvoes can draw enemy forces out or push them back, providing openings for the shuttles to move in and release devastating rocket barrages. Beware, the shuttles are vulnerable to direct fire and missile strikes. Plan your ambush well.</Description>
+  <SortOverrideOrder xsi:nil="true" />
   <Ships>
     <Ship>
       <SaveID xsi:nil="true" />
       <Key>375c83e1-ccd3-41b4-863a-7c9ea5aa5100</Key>
       <Name>Annihilation Theory</Name>
-      <Cost>1661</Cost>
+      <Cost>1669</Cost>
       <Callsign />
-      <Number>515</Number>
+      <Number>401</Number>
       <SymbolOption>0</SymbolOption>
       <HullType>Stock/Ocello Cruiser</HullType>
       <SocketMap>
@@ -46,12 +47,7 @@ This squadron is built around a steadfast capital ship with a supporting utility
               <MagSaveData>
                 <MagazineKey>Vb9bes3eXUKmIqZD4CqkKw</MagazineKey>
                 <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>20</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>qWVvBYsFf0anOoaU-EBSyw</MagazineKey>
-                <MunitionKey>Stock/EA20 Flare Decoy</MunitionKey>
-                <Quantity>7</Quantity>
+                <Quantity>15</Quantity>
               </MagSaveData>
             </MissileLoad>
           </ComponentData>
@@ -64,12 +60,12 @@ This squadron is built around a steadfast capital ship with a supporting utility
               <MagSaveData>
                 <MagazineKey>T5kfNgpJ10WHW0X3LPisEA</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-278 Squamish</MunitionKey>
-                <Quantity>8</Quantity>
+                <Quantity>12</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>EMw7pBPVFkiJ1uFpZDwRfA</MagazineKey>
                 <MunitionKey>$MODMIS$/SGM-273 Helitsuk</MunitionKey>
-                <Quantity>8</Quantity>
+                <Quantity>4</Quantity>
               </MagSaveData>
             </MissileLoad>
             <ConfiguredSize>
@@ -110,12 +106,12 @@ This squadron is built around a steadfast capital ship with a supporting utility
               <MagSaveData>
                 <MagazineKey>nN0ZLp_pnkilWoAlM6rk0A</MagazineKey>
                 <MunitionKey>Stock/450mm HE Shell</MunitionKey>
-                <Quantity>400</Quantity>
+                <Quantity>300</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>iiDgVQYtOEKT1Doaxq5NMA</MagazineKey>
                 <MunitionKey>Stock/450mm AP Shell</MunitionKey>
-                <Quantity>150</Quantity>
+                <Quantity>295</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>XQA7R5moWU2HbcUfvzTGLg</MagazineKey>
@@ -137,12 +133,12 @@ This squadron is built around a steadfast capital ship with a supporting utility
               <MagSaveData>
                 <MagazineKey>_aVqb0J3wkWAWkdSECar-Q</MagazineKey>
                 <MunitionKey>Stock/450mm HE Shell</MunitionKey>
-                <Quantity>300</Quantity>
+                <Quantity>225</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>SeRAyDxqykOIVP-8AS6RnQ</MagazineKey>
                 <MunitionKey>Stock/450mm AP Shell</MunitionKey>
-                <Quantity>100</Quantity>
+                <Quantity>220</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>5cdnVtu7R0KvHM9UUBbwTg</MagazineKey>
@@ -162,11 +158,11 @@ This squadron is built around a steadfast capital ship with a supporting utility
         </HullSocket>
         <HullSocket>
           <Key>S03aWjfX90epbCcytu9_xw</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>aImgD6jcq0GZXRi5MmyeWw</Key>
-          <ComponentName>Stock/Large DC Locker</ComponentName>
+          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>hjHxzsG5iUCkaG0eGd52bA</Key>
@@ -229,15 +225,15 @@ This squadron is built around a steadfast capital ship with a supporting utility
       <SaveID xsi:nil="true" />
       <Key>62c8e7ed-becb-4c64-b62e-76eff5696e50</Key>
       <Name>Paradoxical Thoughts</Name>
-      <Cost>430</Cost>
+      <Cost>452</Cost>
       <Callsign />
-      <Number>515</Number>
+      <Number>402</Number>
       <SymbolOption>0</SymbolOption>
       <HullType>Stock/Bulk Feeder</HullType>
       <SocketMap>
         <HullSocket>
           <Key>4V6twrIUcEKE11tom-tDXQ</Key>
-          <ComponentName>Stock/R400 Radar</ComponentName>
+          <ComponentName>Stock/C54 Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>yN7f-9tEXEKlBNskqP6EbA</Key>
@@ -245,8 +241,8 @@ This squadron is built around a steadfast capital ship with a supporting utility
           <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>dIibOeDHfUaYD0FpeY-cRA</MagazineKey>
-                <MunitionKey>Stock/Decoy Container (Clipper)</MunitionKey>
+                <MagazineKey>eDSvap0xeEmjIF7G_VKSZg</MagazineKey>
+                <MunitionKey>Stock/Rocket Container</MunitionKey>
                 <Quantity>2</Quantity>
               </MagSaveData>
             </MissileLoad>
@@ -258,8 +254,8 @@ This squadron is built around a steadfast capital ship with a supporting utility
           <ComponentData xsi:type="CellLauncherData">
             <MissileLoad>
               <MagSaveData>
-                <MagazineKey>7G9w6G001EGf3AC-BxhWkw</MagazineKey>
-                <MunitionKey>Stock/Decoy Container (Clipper)</MunitionKey>
+                <MagazineKey>VpaW83l6IEKzk54x1cToqw</MagazineKey>
+                <MunitionKey>Stock/Rocket Container</MunitionKey>
                 <Quantity>2</Quantity>
               </MagSaveData>
             </MissileLoad>
@@ -285,7 +281,17 @@ This squadron is built around a steadfast capital ship with a supporting utility
               <MagSaveData>
                 <MagazineKey>REMghGSnH0OQvL8LQTSGQw</MagazineKey>
                 <MunitionKey>Stock/20mm Slug</MunitionKey>
-                <Quantity>8000</Quantity>
+                <Quantity>16000</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>61WQho2b3UazJqMZdb4p5Q</MagazineKey>
+                <MunitionKey>Stock/250mm AP Shell</MunitionKey>
+                <Quantity>300</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>TiFk6Ibnnk-Zg5CaPe-Gng</MagazineKey>
+                <MunitionKey>Stock/250mm HE Shell</MunitionKey>
+                <Quantity>400</Quantity>
               </MagSaveData>
             </Load>
           </ComponentData>
@@ -312,31 +318,49 @@ This squadron is built around a steadfast capital ship with a supporting utility
         </HullSocket>
         <HullSocket>
           <Key>HNv6B-78FEuhV8YT9A6uZw</Key>
-          <ComponentName>Stock/CHI-777 Yard Drive</ComponentName>
+          <ComponentName>Stock/BW800 Drive</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>HvdEBsnpUUypPN4uW67paQ</Key>
-          <ComponentName>Stock/Track Correlator</ComponentName>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>iDdlfFwKkUO9HbumzymceA</Key>
-          <ComponentName>Stock/Track Correlator</ComponentName>
+          <ComponentName>Stock/Ammunition Elevators</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>DaqWEX-8gEeIzYrhp8NIMw</Key>
-          <ComponentName>Stock/Bulwark Huntress</ComponentName>
+          <Key>EvZ6JN5xV0aUlKEeeKxFTQ</Key>
+          <ComponentName>Stock/Missile Programming Bus</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>CU_oraqJxEaB3dTzZW2MkA</Key>
+          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
         </HullSocket>
       </SocketMap>
-      <WeaponGroups />
+      <WeaponGroups>
+        <WepGroup Name="Backup Gun">
+          <MemberKeys>
+            <string>4V6twrIUcEKE11tom-tDXQ</string>
+          </MemberKeys>
+        </WepGroup>
+      </WeaponGroups>
+      <InitialFormation>
+        <GuideKey>375c83e1-ccd3-41b4-863a-7c9ea5aa5100</GuideKey>
+        <RelativePosition>
+          <x>14.190155</x>
+          <y>14.9896317</y>
+          <z>-21.8028717</z>
+        </RelativePosition>
+      </InitialFormation>
       <TemplateMissileTypes />
     </Ship>
     <Ship>
       <SaveID xsi:nil="true" />
       <Key>67e63689-8d0a-4775-9077-40c30965789c</Key>
       <Name>Error Of Your Ways</Name>
-      <Cost>303</Cost>
+      <Cost>293</Cost>
       <Callsign />
-      <Number>515</Number>
+      <Number>711</Number>
       <SymbolOption>0</SymbolOption>
       <HullType>Stock/Shuttle</HullType>
       <SocketMap>
@@ -392,7 +416,7 @@ This squadron is built around a steadfast capital ship with a supporting utility
         </HullSocket>
         <HullSocket>
           <Key>zUeDN4FpYEyyWHIhTIgZFg</Key>
-          <ComponentName>Stock/Bulwark Huntress</ComponentName>
+          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>uXJ_fvsZ3USAs1SpiTrZ1g</Key>
@@ -405,10 +429,10 @@ This squadron is built around a steadfast capital ship with a supporting utility
     <Ship>
       <SaveID xsi:nil="true" />
       <Key>f841c3ce-4856-4c57-8f28-ab9e2df7b2ca</Key>
-      <Name>Best Kept Secret</Name>
-      <Cost>303</Cost>
+      <Name>Under The Floor</Name>
+      <Cost>293</Cost>
       <Callsign />
-      <Number>515</Number>
+      <Number>712</Number>
       <SymbolOption>0</SymbolOption>
       <HullType>Stock/Shuttle</HullType>
       <SocketMap>
@@ -464,7 +488,7 @@ This squadron is built around a steadfast capital ship with a supporting utility
         </HullSocket>
         <HullSocket>
           <Key>zUeDN4FpYEyyWHIhTIgZFg</Key>
-          <ComponentName>Stock/Bulwark Huntress</ComponentName>
+          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>uXJ_fvsZ3USAs1SpiTrZ1g</Key>
@@ -472,23 +496,15 @@ This squadron is built around a steadfast capital ship with a supporting utility
         </HullSocket>
       </SocketMap>
       <WeaponGroups />
-      <InitialFormation>
-        <GuideKey>67e63689-8d0a-4775-9077-40c30965789c</GuideKey>
-        <RelativePosition>
-          <x>-21.3899612</x>
-          <y>0</y>
-          <z>-25.5201721</z>
-        </RelativePosition>
-      </InitialFormation>
       <TemplateMissileTypes />
     </Ship>
     <Ship>
       <SaveID xsi:nil="true" />
       <Key>b2ec53ad-54c2-4387-a82a-7d59846c3dd8</Key>
       <Name>Bump In The Night</Name>
-      <Cost>303</Cost>
+      <Cost>293</Cost>
       <Callsign />
-      <Number>515</Number>
+      <Number>713</Number>
       <SymbolOption>0</SymbolOption>
       <HullType>Stock/Shuttle</HullType>
       <SocketMap>
@@ -544,7 +560,7 @@ This squadron is built around a steadfast capital ship with a supporting utility
         </HullSocket>
         <HullSocket>
           <Key>zUeDN4FpYEyyWHIhTIgZFg</Key>
-          <ComponentName>Stock/Bulwark Huntress</ComponentName>
+          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>uXJ_fvsZ3USAs1SpiTrZ1g</Key>
@@ -552,14 +568,6 @@ This squadron is built around a steadfast capital ship with a supporting utility
         </HullSocket>
       </SocketMap>
       <WeaponGroups />
-      <InitialFormation>
-        <GuideKey>67e63689-8d0a-4775-9077-40c30965789c</GuideKey>
-        <RelativePosition>
-          <x>18.548317</x>
-          <y>0</y>
-          <z>-27.6689911</z>
-        </RelativePosition>
-      </InitialFormation>
       <TemplateMissileTypes />
     </Ship>
   </Ships>
@@ -581,6 +589,7 @@ Terminal Maneuvers: None
 Contact Fuze, High Explosive, Shaped
 Armor: 54cm   Component: 960hp
 Blast Angle: 70 deg
+Damage Per Fragment: 50.0
 
 Body Integrity: 30 
 Programming Time: 8 s
@@ -627,6 +636,7 @@ Failure Rate: 0 %</LongDescription>
             <Maneuvers>None</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
@@ -656,14 +666,14 @@ Failure Rate: 0 %</LongDescription>
     <MissileTemplate>
       <Designation>SGM-278</Designation>
       <Nickname>Squamish</Nickname>
-      <Description>DIRECT - &lt;color=#FBFF4C&gt;CMD&lt;/color&gt;/ACT(&lt;color=#4CFF72&gt;RADAR&lt;/color&gt;) - HE SHAPED</Description>
-      <LongDescription>The SGM-278 Squamish is a size 2 direct guidance missile.  It is based on the SGM-2 body, which is a flexible mainstay anti-ship missile.  This missile will deliver a Contact Fuze, High Explosive, Shaped warhead.  It homes in on its target using command guidance from its launching ship  If the primary seeker does not find a target or is jammed, it can fall back on an Active Radar seeker.
+      <Description>DIRECT - ACT(&lt;color=#4CFF72&gt;RADAR&lt;/color&gt;)/[&lt;color=#FBFF4C&gt;CMD&lt;/color&gt;] - HE SHAPED</Description>
+      <LongDescription>The SGM-278 Squamish is a size 2 direct guidance missile.  It is based on the SGM-2 body, which is a flexible mainstay anti-ship missile.  This missile will deliver a Contact Fuze, High Explosive, Shaped warhead.  It homes in on its target using an Active Radar seeker, validating that it is the correct target using command guidance from its launching ship.
 
 Control Method: DIRECT
 Targeting Modes:
-	&lt;b&gt;&lt;color=#4CFF72&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
-Primary Seeker: COMMAND (&lt;color=#FBFF4C&gt;Requires COMMS Enabled&lt;/color&gt;)
-Backup Seeker(s): ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
+	&lt;b&gt;&lt;color=#FBFF4C&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
+Primary Seeker: ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
+Validation Seeker(s): COMMAND (&lt;color=#FBFF4C&gt;Requires COMMS Enabled&lt;/color&gt;)
 
 310 m/s for 7,464 m, top speed in 2.1 s
 Terminal Maneuvers: None
@@ -671,6 +681,7 @@ Terminal Maneuvers: None
 Contact Fuze, High Explosive, Shaped
 Armor: 66cm   Component: 1,440hp
 Blast Angle: 70 deg
+Damage Per Fragment: 50.0
 
 Body Integrity: 30 
 Programming Time: 8 s
@@ -697,19 +708,19 @@ Failure Rate: 0 %</LongDescription>
       <Sockets>
         <MissileSocket>
           <Size>1</Size>
-          <InstalledComponent xsi:type="CommandSeekerSettings">
-            <ComponentKey>Stock/Command Receiver</ComponentKey>
+          <InstalledComponent xsi:type="ActiveSeekerSettings">
+            <ComponentKey>Stock/Steerable Active Radar Seeker</ComponentKey>
             <Mode>Targeting</Mode>
             <RejectUnvalidated>false</RejectUnvalidated>
+            <DetectPDTargets>false</DetectPDTargets>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
           <Size>1</Size>
-          <InstalledComponent xsi:type="ActiveSeekerSettings">
-            <ComponentKey>Stock/Fixed Active Radar Seeker</ComponentKey>
-            <Mode>Targeting</Mode>
+          <InstalledComponent xsi:type="CommandSeekerSettings">
+            <ComponentKey>Stock/Command Receiver</ComponentKey>
+            <Mode>Validation</Mode>
             <RejectUnvalidated>false</RejectUnvalidated>
-            <DetectPDTargets>false</DetectPDTargets>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
@@ -722,6 +733,7 @@ Failure Rate: 0 %</LongDescription>
             <Maneuvers>None</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>0</SalvoSize>
               <FarthestFirst>false</FarthestFirst>

--- a/data/fleets/Zircon Squadron.fleet
+++ b/data/fleets/Zircon Squadron.fleet
@@ -6,13 +6,14 @@
   <FactionKey>Stock/Protectorate</FactionKey>
   <Description>Difficulty: &lt;color=red&gt;HARD&lt;/color&gt;
 
-This squadron flips the script on typical Lineship design, requiring the support of its escorting Monitors firing plasma to open up holes in enemy armor to allow its massive volume of 100mm fire to penetrate.  The fleet has good point defenses, including 60 interceptor missiles, to protect against missile attack.  It also features a scout/ewar shuttle.</Description>
+Zircon Squadron is an extreme example of ship specialization. The lineship can unleash a massive volume of 100mm fire, but it requires the support of the plasma monitors to engage heavier targets. To plan its ambushes, the fleet features a tugboat with an early warning radar, used to detect the enemy in advance.</Description>
+  <SortOverrideOrder>6</SortOverrideOrder>
   <Ships>
     <Ship>
       <SaveID xsi:nil="true" />
       <Key>bb1d52c0-57b2-4500-a35d-f6deddba5577</Key>
       <Name>Secrets Best Left Known</Name>
-      <Cost>1683</Cost>
+      <Cost>1464</Cost>
       <Callsign />
       <Number>1150</Number>
       <SymbolOption>0</SymbolOption>
@@ -102,7 +103,7 @@ This squadron flips the script on typical Lineship design, requiring the support
         </HullSocket>
         <HullSocket>
           <Key>9EF9u0V1eUetleBnkQhHkA</Key>
-          <ComponentName>Stock/RF44 'Pinpoint' Radar</ComponentName>
+          <ComponentName>Stock/P11 PDT</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>I68tNng-K0yG-AoUx0HcSw</Key>
@@ -116,7 +117,7 @@ This squadron flips the script on typical Lineship design, requiring the support
               <MagSaveData>
                 <MagazineKey>hTOK1i4jP0W8MdxdA7N9Xg</MagazineKey>
                 <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>15</Quantity>
+                <Quantity>12</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>erupgZIFq0uTv2vZRg50nA</MagazineKey>
@@ -134,7 +135,7 @@ This squadron flips the script on typical Lineship design, requiring the support
               <MagSaveData>
                 <MagazineKey>phzT0fDtcE-7ECF3IgmTlg</MagazineKey>
                 <MunitionKey>Stock/EA12 Chaff Decoy</MunitionKey>
-                <Quantity>15</Quantity>
+                <Quantity>12</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>e9UHPgDnlkm16EiSnxxq9A</MagazineKey>
@@ -164,34 +165,34 @@ This squadron flips the script on typical Lineship design, requiring the support
               <MagSaveData>
                 <MagazineKey>Vi69RnPSJ0eROF-q0dJ-Pw</MagazineKey>
                 <MunitionKey>Stock/100mm AP Shell</MunitionKey>
-                <Quantity>6400</Quantity>
+                <Quantity>6000</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>RvImVIWYQEaJ8fuZAGi4bQ</MagazineKey>
                 <MunitionKey>Stock/100mm HE Shell</MunitionKey>
-                <Quantity>6400</Quantity>
+                <Quantity>6000</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>xn_HafDD9EKpg1DhG0Zvwg</MagazineKey>
                 <MunitionKey>Stock/100mm HE-HC Shell</MunitionKey>
-                <Quantity>6400</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>jrXYBBbfqUWRyKoRWLD8-Q</MagazineKey>
-                <MunitionKey>Stock/100mm Grapeshot</MunitionKey>
-                <Quantity>3200</Quantity>
+                <Quantity>6000</Quantity>
               </MagSaveData>
               <MagSaveData>
                 <MagazineKey>mqsvjbP25UirDkExLHhppg</MagazineKey>
                 <MunitionKey>Stock/20mm Slug</MunitionKey>
                 <Quantity>28000</Quantity>
               </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>6OWRwXsbLkCX7V5_FGTj4Q</MagazineKey>
+                <MunitionKey>Stock/100mm Grapeshot</MunitionKey>
+                <Quantity>6000</Quantity>
+              </MagSaveData>
             </Load>
           </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>fYoX2amTl0KrZurPKjU9gg</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <ComponentName>Stock/Damage Control Complex</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>T9TN0ZYumUaCxcSRjO_qTw</Key>
@@ -211,7 +212,7 @@ This squadron flips the script on typical Lineship design, requiring the support
         </HullSocket>
         <HullSocket>
           <Key>FVcPIcV_00eu62NQQK3oLg</Key>
-          <ComponentName>Stock/Damage Control Central</ComponentName>
+          <ComponentName>Stock/Plant Control Center</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>1FrTJ5o850ynlq4dRDmMbA</Key>
@@ -223,7 +224,7 @@ This squadron flips the script on typical Lineship design, requiring the support
         </HullSocket>
         <HullSocket>
           <Key>6evWdeLGT0uALe075-nhgw</Key>
-          <ComponentName>Stock/Boosted Reactor</ComponentName>
+          <ComponentName>Stock/Civilian Reactor</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>JVCLf3RKKUOBEXaWWkVLMw</Key>
@@ -273,8 +274,8 @@ This squadron flips the script on typical Lineship design, requiring the support
     <Ship>
       <SaveID xsi:nil="true" />
       <Key>20b6b415-926f-4157-b999-57d215009372</Key>
-      <Name>Salt Sower</Name>
-      <Cost>533</Cost>
+      <Name>One Too Many</Name>
+      <Cost>613</Cost>
       <Callsign />
       <Number>1207</Number>
       <SymbolOption>0</SymbolOption>
@@ -282,7 +283,7 @@ This squadron flips the script on typical Lineship design, requiring the support
       <SocketMap>
         <HullSocket>
           <Key>4V6twrIUcEKE11tom-tDXQ</Key>
-          <ComponentName>Stock/RF44 'Pinpoint' Radar</ComponentName>
+          <ComponentName>Stock/C81 Plasma Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>yN7f-9tEXEKlBNskqP6EbA</Key>
@@ -306,7 +307,21 @@ This squadron flips the script on typical Lineship design, requiring the support
         </HullSocket>
         <HullSocket>
           <Key>vtme83CXg0qDA4_YK6NqwA</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <ComponentName>Stock/Citadel Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>bc6GWiii3kOr80G4fwMy0A</MagazineKey>
+                <MunitionKey>Stock/400mm Plasma Ampoule</MunitionKey>
+                <Quantity>500</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>6MnHOq3V40eRIQnDejTszA</MagazineKey>
+                <MunitionKey>Stock/Flak Round</MunitionKey>
+                <Quantity>600</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>TTM8O-MUDky06__LwvSo8w</Key>
@@ -314,7 +329,7 @@ This squadron flips the script on typical Lineship design, requiring the support
         </HullSocket>
         <HullSocket>
           <Key>rGVFgJ8GyUePoRkz33c1sw</Key>
-          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+          <ComponentName>Stock/Plant Control Center</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>_hUvj899GkWP0bnjDN1ODw</Key>
@@ -322,21 +337,7 @@ This squadron flips the script on typical Lineship design, requiring the support
         </HullSocket>
         <HullSocket>
           <Key>N4KIOsNqeUGVAUrx5OW3DQ</Key>
-          <ComponentName>Stock/Reinforced Magazine</ComponentName>
-          <ComponentData xsi:type="BulkMagazineData">
-            <Load>
-              <MagSaveData>
-                <MagazineKey>HgNsF2U5qki2I0RtiQ7tVA</MagazineKey>
-                <MunitionKey>Stock/400mm Plasma Ampoule</MunitionKey>
-                <Quantity>200</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>FDGRayfEcEewSzOGlC53dw</MagazineKey>
-                <MunitionKey>Stock/Flak Round</MunitionKey>
-                <Quantity>1125</Quantity>
-              </MagSaveData>
-            </Load>
-          </ComponentData>
+          <ComponentName>Stock/Large DC Storage</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>9K_1ZNCgFESrvaoQMOH3yw</Key>
@@ -348,7 +349,7 @@ This squadron flips the script on typical Lineship design, requiring the support
         </HullSocket>
         <HullSocket>
           <Key>HvdEBsnpUUypPN4uW67paQ</Key>
-          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
+          <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>iDdlfFwKkUO9HbumzymceA</Key>
@@ -356,7 +357,15 @@ This squadron flips the script on typical Lineship design, requiring the support
         </HullSocket>
         <HullSocket>
           <Key>DaqWEX-8gEeIzYrhp8NIMw</Key>
-          <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
+          <ComponentName>Stock/Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>EvZ6JN5xV0aUlKEeeKxFTQ</Key>
+          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>CU_oraqJxEaB3dTzZW2MkA</Key>
+          <ComponentName>Stock/Small Reactor Booster</ComponentName>
         </HullSocket>
       </SocketMap>
       <WeaponGroups>
@@ -366,30 +375,27 @@ This squadron flips the script on typical Lineship design, requiring the support
             <string>Z2uDs34J-ESu64-i9YGnxQ</string>
           </MemberKeys>
         </WepGroup>
+        <WepGroup Name="Plasma Spinal">
+          <MemberKeys>
+            <string>4V6twrIUcEKE11tom-tDXQ</string>
+          </MemberKeys>
+        </WepGroup>
       </WeaponGroups>
-      <InitialFormation>
-        <GuideKey>bb1d52c0-57b2-4500-a35d-f6deddba5577</GuideKey>
-        <RelativePosition>
-          <x>-30.724844</x>
-          <y>0</y>
-          <z>-39.39796</z>
-        </RelativePosition>
-      </InitialFormation>
       <TemplateMissileTypes />
     </Ship>
     <Ship>
       <SaveID xsi:nil="true" />
-      <Key>39650b9d-7960-476f-88f8-9245826e2434</Key>
-      <Name>Salt Balm</Name>
-      <Cost>533</Cost>
+      <Key>21fe3856-ff51-4fad-a85c-b427ac4ea1ee</Key>
+      <Name>Bring Your Own</Name>
+      <Cost>613</Cost>
       <Callsign />
-      <Number>1292</Number>
+      <Number>1283</Number>
       <SymbolOption>0</SymbolOption>
       <HullType>Stock/Bulk Feeder</HullType>
       <SocketMap>
         <HullSocket>
           <Key>4V6twrIUcEKE11tom-tDXQ</Key>
-          <ComponentName>Stock/RF44 'Pinpoint' Radar</ComponentName>
+          <ComponentName>Stock/C81 Plasma Cannon</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>yN7f-9tEXEKlBNskqP6EbA</Key>
@@ -413,7 +419,21 @@ This squadron flips the script on typical Lineship design, requiring the support
         </HullSocket>
         <HullSocket>
           <Key>vtme83CXg0qDA4_YK6NqwA</Key>
-          <ComponentName>Stock/Rapid DC Locker</ComponentName>
+          <ComponentName>Stock/Citadel Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load>
+              <MagSaveData>
+                <MagazineKey>bc6GWiii3kOr80G4fwMy0A</MagazineKey>
+                <MunitionKey>Stock/400mm Plasma Ampoule</MunitionKey>
+                <Quantity>500</Quantity>
+              </MagSaveData>
+              <MagSaveData>
+                <MagazineKey>6MnHOq3V40eRIQnDejTszA</MagazineKey>
+                <MunitionKey>Stock/Flak Round</MunitionKey>
+                <Quantity>600</Quantity>
+              </MagSaveData>
+            </Load>
+          </ComponentData>
         </HullSocket>
         <HullSocket>
           <Key>TTM8O-MUDky06__LwvSo8w</Key>
@@ -421,7 +441,7 @@ This squadron flips the script on typical Lineship design, requiring the support
         </HullSocket>
         <HullSocket>
           <Key>rGVFgJ8GyUePoRkz33c1sw</Key>
-          <ComponentName>Stock/Reinforced DC Locker</ComponentName>
+          <ComponentName>Stock/Plant Control Center</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>_hUvj899GkWP0bnjDN1ODw</Key>
@@ -429,21 +449,7 @@ This squadron flips the script on typical Lineship design, requiring the support
         </HullSocket>
         <HullSocket>
           <Key>N4KIOsNqeUGVAUrx5OW3DQ</Key>
-          <ComponentName>Stock/Reinforced Magazine</ComponentName>
-          <ComponentData xsi:type="BulkMagazineData">
-            <Load>
-              <MagSaveData>
-                <MagazineKey>HgNsF2U5qki2I0RtiQ7tVA</MagazineKey>
-                <MunitionKey>Stock/400mm Plasma Ampoule</MunitionKey>
-                <Quantity>200</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>FDGRayfEcEewSzOGlC53dw</MagazineKey>
-                <MunitionKey>Stock/Flak Round</MunitionKey>
-                <Quantity>1125</Quantity>
-              </MagSaveData>
-            </Load>
-          </ComponentData>
+          <ComponentName>Stock/Large DC Storage</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>9K_1ZNCgFESrvaoQMOH3yw</Key>
@@ -455,7 +461,7 @@ This squadron flips the script on typical Lineship design, requiring the support
         </HullSocket>
         <HullSocket>
           <Key>HvdEBsnpUUypPN4uW67paQ</Key>
-          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
+          <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
         </HullSocket>
         <HullSocket>
           <Key>iDdlfFwKkUO9HbumzymceA</Key>
@@ -463,7 +469,15 @@ This squadron flips the script on typical Lineship design, requiring the support
         </HullSocket>
         <HullSocket>
           <Key>DaqWEX-8gEeIzYrhp8NIMw</Key>
-          <ComponentName>Stock/Rapid-Cycle Cradle</ComponentName>
+          <ComponentName>Stock/Energy Regulator</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>EvZ6JN5xV0aUlKEeeKxFTQ</Key>
+          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>CU_oraqJxEaB3dTzZW2MkA</Key>
+          <ComponentName>Stock/Small Reactor Booster</ComponentName>
         </HullSocket>
       </SocketMap>
       <WeaponGroups>
@@ -473,90 +487,80 @@ This squadron flips the script on typical Lineship design, requiring the support
             <string>Z2uDs34J-ESu64-i9YGnxQ</string>
           </MemberKeys>
         </WepGroup>
+        <WepGroup Name="Plasma Spinal">
+          <MemberKeys>
+            <string>4V6twrIUcEKE11tom-tDXQ</string>
+          </MemberKeys>
+        </WepGroup>
       </WeaponGroups>
-      <InitialFormation>
-        <GuideKey>bb1d52c0-57b2-4500-a35d-f6deddba5577</GuideKey>
-        <RelativePosition>
-          <x>28.8519363</x>
-          <y>0</y>
-          <z>-40.87425</z>
-        </RelativePosition>
-      </InitialFormation>
       <TemplateMissileTypes />
     </Ship>
     <Ship>
       <SaveID xsi:nil="true" />
-      <Key>bdbf924b-1c56-42a3-8aa0-4499c11e436e</Key>
-      <Name>Elder Hall</Name>
-      <Cost>251</Cost>
+      <Key>bc926495-0609-495d-a8c6-fd1f25f579de</Key>
+      <Name>Silver For The Ferryman
+</Name>
+      <Cost>310</Cost>
       <Callsign />
-      <Number>966</Number>
+      <Number>1335</Number>
       <SymbolOption>0</SymbolOption>
-      <HullType>Stock/Shuttle</HullType>
+      <HullType>Stock/Tugboat</HullType>
       <SocketMap>
         <HullSocket>
-          <Key>3mlCA6C6m0GI3wONZK_aqg</Key>
-          <ComponentName>Stock/T20 Cannon</ComponentName>
+          <Key>cIGspM4oYU2etRfjIcuCCA</Key>
+          <ComponentName>Stock/R550 Early Warning Radar</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>fbAgHM9u302peFMSC0TidQ</Key>
-          <ComponentName>Stock/J15 Jammer</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>rbZhGCN7UUWcgLsNZkZXIA</Key>
-          <ComponentName>Stock/RF44 'Pinpoint' Radar</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>hh8PA01jxEytn9KuihcJ3Q</Key>
-          <ComponentName>Stock/Reinforced CIC</ComponentName>
-        </HullSocket>
-        <HullSocket>
-          <Key>wDWAeeoAK0mAx3hbF1tMlA</Key>
-          <ComponentName>Stock/Reinforced Magazine</ComponentName>
-          <ComponentData xsi:type="BulkMagazineData">
-            <Load>
+          <Key>0upOgm0H0UuZ-h2YvRjmBg</Key>
+          <ComponentName>Stock/VLS-1-46 Launcher</ComponentName>
+          <ComponentData xsi:type="CellLauncherData">
+            <MissileLoad>
               <MagSaveData>
-                <MagazineKey>E7tHctJ-3kSP3uHH-gfeWA</MagazineKey>
-                <MunitionKey>Stock/100mm AP Shell</MunitionKey>
-                <Quantity>300</Quantity>
+                <MagazineKey>sM0ODuSU8kCHsJyxLkJkPg</MagazineKey>
+                <MunitionKey>$MODMIS$/SGM-162 Guardian</MunitionKey>
+                <Quantity>20</Quantity>
               </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>8hT5JcI5mUWLXV3XLTNNew</MagazineKey>
-                <MunitionKey>Stock/100mm HE Shell</MunitionKey>
-                <Quantity>300</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>8kyJGE72Sk6_jV1hU3ccoA</MagazineKey>
-                <MunitionKey>Stock/100mm HE-HC Shell</MunitionKey>
-                <Quantity>300</Quantity>
-              </MagSaveData>
-              <MagSaveData>
-                <MagazineKey>Nn1aKfNTskWvFbQWgUMNuA</MagazineKey>
-                <MunitionKey>Stock/100mm Grapeshot</MunitionKey>
-                <Quantity>200</Quantity>
-              </MagSaveData>
-            </Load>
+            </MissileLoad>
           </ComponentData>
         </HullSocket>
         <HullSocket>
-          <Key>CcSXjIupV0Kw-jxaV6HpEA</Key>
-          <ComponentName>Stock/Small DC Locker</ComponentName>
+          <Key>F6bmJdCO3EqzXK9SBJoXUw</Key>
+          <ComponentName>Stock/Basic CIC</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>bInyh5AAt0y_m-3UaI8Ysw</Key>
-          <ComponentName>Stock/Light Civilian Reactor</ComponentName>
+          <Key>-PqoLKimSUOZtKMLo5QHXg</Key>
+          <ComponentName>Stock/Berthing</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>-harMwD0o0OExuMqT63fTQ</Key>
-          <ComponentName>Stock/BW800-R Drive</ComponentName>
+          <Key>DakKS2gy6UyM58u3YG-HfQ</Key>
+          <ComponentName>Stock/Reinforced Magazine</ComponentName>
+          <ComponentData xsi:type="BulkMagazineData">
+            <Load />
+          </ComponentData>
         </HullSocket>
         <HullSocket>
-          <Key>zUeDN4FpYEyyWHIhTIgZFg</Key>
-          <ComponentName>Stock/Bulwark Huntress</ComponentName>
+          <Key>peqaYrE39UupWCXPY_PgoA</Key>
+          <ComponentName>Stock/Rapid DC Locker</ComponentName>
         </HullSocket>
         <HullSocket>
-          <Key>uXJ_fvsZ3USAs1SpiTrZ1g</Key>
-          <ComponentName>Stock/Small Reactor Booster</ComponentName>
+          <Key>6OieSH0A6kKFmquctn9_aQ</Key>
+          <ComponentName>Stock/Plant Control Center</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>NSAbhn9brE-aAirJFIYG-Q</Key>
+          <ComponentName>Stock/Boosted Reactor</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>_qlP8rsUpUiJpkRc1tcjPQ</Key>
+          <ComponentName>Stock/BW800 Drive</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>RMDTRlITGUm1ZgbIgWq1Xw</Key>
+          <ComponentName>Stock/Ithaca Bridgemaster</ComponentName>
+        </HullSocket>
+        <HullSocket>
+          <Key>v7vnexI1xUemaSmSkn0QNA</Key>
+          <ComponentName>Stock/Adaptive Radar Receiver</ComponentName>
         </HullSocket>
       </SocketMap>
       <WeaponGroups />
@@ -575,12 +579,12 @@ Targeting Modes:
 	&lt;b&gt;&lt;color=#4CFF72&gt;POSITION&lt;/color&gt;	&lt;color=#4CFF72&gt;TRACK&lt;/color&gt;&lt;/b&gt;
 Primary Seeker: ACTIVE &lt;color=#4CFF72&gt;RADAR&lt;/color&gt;
 
-285 m/s for 4,070 m, top speed in 0.5 s
+286 m/s for 4,117 m, top speed in 0.5 s
 Terminal Maneuvers: None
 
 Proximity Fuze, High Explosive, Blast Fragmentation
-Armor: 1cm   Component: 40hp
-Blast Radius: 43 m
+Armor: 2cm   Component: 33hp
+Blast Radius: 30 m
 
 Body Integrity: 10 
 Programming Time: 6 s
@@ -589,7 +593,7 @@ Boost-Phase Duration: 3 s
 Boost-Phase Strafe: 100 %
 Boost-Phase Turn Rate: 100 %
 Failure Rate: 0 %</LongDescription>
-      <Cost>4</Cost>
+      <Cost>3</Cost>
       <BodyKey>Stock/SGM-1 Body</BodyKey>
       <TemplateKey>7437b367-02e1-4581-b13b-19a63d3533a7</TemplateKey>
       <BaseColor>
@@ -619,11 +623,12 @@ Failure Rate: 0 %</LongDescription>
           <InstalledComponent xsi:type="DirectGuidanceSettings">
             <ComponentKey>Stock/Direct Guidance</ComponentKey>
             <Role>Defensive</Role>
-            <HotLaunch>false</HotLaunch>
+            <HotLaunch>true</HotLaunch>
             <SelfDestructOnLost>false</SelfDestructOnLost>
             <Maneuvers>None</Maneuvers>
             <DefensiveDoctrine>
               <TargetSizeMask>12</TargetSizeMask>
+              <TargetType>All</TargetType>
               <TargetSizeOrdering>Descending</TargetSizeOrdering>
               <SalvoSize>1</SalvoSize>
               <FarthestFirst>false</FarthestFirst>
@@ -632,19 +637,19 @@ Failure Rate: 0 %</LongDescription>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>2</Size>
+          <Size>1</Size>
           <InstalledComponent>
             <ComponentKey>Stock/Blast Fragmentation EL</ComponentKey>
           </InstalledComponent>
         </MissileSocket>
         <MissileSocket>
-          <Size>5</Size>
+          <Size>6</Size>
           <InstalledComponent xsi:type="MissileEngineSettings">
             <ComponentKey />
             <BalanceValues>
-              <A>0.2306254</A>
-              <B>0.15130426</B>
-              <C>0.618070364</C>
+              <A>0.238845631</A>
+              <B>0.07314026</B>
+              <C>0.6880141</C>
             </BalanceValues>
           </InstalledComponent>
         </MissileSocket>

--- a/data/hulls/0_stock_bulk_feeder.json
+++ b/data/hulls/0_stock_bulk_feeder.json
@@ -2,7 +2,7 @@
   "key": "Stock/Bulk Feeder",
   "name": "'Cargo Feeder' class Monitor",
   "mounts": {
-    "4V6twrIUcEKE11tom-tDXQ": "4x10x4",
+    "4V6twrIUcEKE11tom-tDXQ": "6x12x6",
     "yN7f-9tEXEKlBNskqP6EbA": "6x4x6",
     "Z2uDs34J-ESu64-i9YGnxQ": "6x4x6",
     "gb6_3kWBY0KlEWeex3ruDg": "3x2x5",
@@ -21,6 +21,8 @@
     "HNv6B-78FEuhV8YT9A6uZw": "10x5x8",
     "HvdEBsnpUUypPN4uW67paQ": "3x3x3",
     "iDdlfFwKkUO9HbumzymceA": "3x3x3",
-    "DaqWEX-8gEeIzYrhp8NIMw": "3x3x3"
+    "DaqWEX-8gEeIzYrhp8NIMw": "3x3x3",
+    "EvZ6JN5xV0aUlKEeeKxFTQ": "2x2x2",
+    "CU_oraqJxEaB3dTzZW2MkA": "2x2x2"
   }
 }

--- a/data/munitions.json
+++ b/data/munitions.json
@@ -1,0 +1,196 @@
+{
+  "Munitions": [
+    {
+      "Key": "Stock/250mm HE Shell",
+      "Name": "250mm HE Shell",
+      "PointCost": "1",
+      "PointDivision": "50"
+    },
+    {
+      "Key": "Stock/250mm AP Shell",
+      "Name": "250mm AP Shell",
+      "PointCost": "1",
+      "PointDivision": "50"
+    },
+    {
+      "Key": "Stock/250mm HE-RPF Shell",
+      "Name": "250mm HE-RPF Shell",
+      "PointCost": "1",
+      "PointDivision": "50"
+    },
+    {
+      "Key": "Stock/450mm HE Shell",
+      "Name": "450mm HE Shell",
+      "PointCost": "1",
+      "PointDivision": "25"
+    },
+    {
+      "Key": "Stock/450mm AP Shell",
+      "Name": "450mm AP Shell",
+      "PointCost": "1",
+      "PointDivision": "25"
+    },
+    {
+      "Key": "Stock/20mm Slug",
+      "Name": "20mm Slug",
+      "PointCost": "1",
+      "PointDivision": "2000"
+    },
+    {
+      "Key": "Stock/Flak Round",
+      "Name": "Flak Round",
+      "PointCost": "1",
+      "PointDivision": "75"
+    },
+    {
+      "Key": "Stock/120mm HE Shell",
+      "Name": "120mm HE Shell",
+      "PointCost": "1",
+      "PointDivision": "100"
+    },
+    {
+      "Key": "Stock/120mm AP Shell",
+      "Name": "120mm AP Shell",
+      "PointCost": "1",
+      "PointDivision": "100"
+    },
+    {
+      "Key": "Stock/120mm HE-RPF Shell",
+      "Name": "120mm HE-RPF Shell",
+      "PointCost": "1",
+      "PointDivision": "100"
+    },
+    {
+      "Key": "Stock/15mm Sandshot",
+      "Name": "15mm Sandshot",
+      "PointCost": "1",
+      "PointDivision": "50"
+    },
+    {
+      "Key": "Stock/300mm AP Rail Sabot",
+      "Name": "300mm AP Rail Sabot",
+      "PointCost": "1",
+      "PointDivision": "25"
+    },
+    {
+      "Key": "Stock/EA12 Chaff Decoy",
+      "Name": "EA12 Chaff Decoy",
+      "PointCost": "1",
+      "PointDivision": "1"
+    },
+    {
+      "Key": "Stock/EA20 Flare Decoy",
+      "Name": "EA20 Flare Decoy",
+      "PointCost": "1",
+      "PointDivision": "1"
+    },
+    {
+      "Key": "Stock/EA99 Active Decoy",
+      "Name": "EA99 Active Decoy",
+      "PointCost": "8",
+      "PointDivision": "1"
+    },
+    {
+      "Key": "Stock/100mm HE Shell",
+      "Name": "100mm HE Shell",
+      "PointCost": "1",
+      "PointDivision": "250"
+    },
+    {
+      "Key": "Stock/100mm HE-HC Shell",
+      "Name": "100mm HE-HC Shell",
+      "PointCost": "1",
+      "PointDivision": "250"
+    },
+    {
+      "Key": "Stock/100mm AP Shell",
+      "Name": "100mm AP Shell",
+      "PointCost": "1",
+      "PointDivision": "250"
+    },
+    {
+      "Key": "Stock/100mm Grapeshot",
+      "Name": "100mm Grape",
+      "PointCost": "1",
+      "PointDivision": "250"
+    },
+    {
+      "Key": "Stock/400mm Plasma Ampoule",
+      "Name": "400mm Plasma Ampoule",
+      "PointCost": "1",
+      "PointDivision": "25"
+    },
+    {
+      "Key": "Stock/500mm Fracturing Block",
+      "Name": "500mm Fracturing Block",
+      "PointCost": "1",
+      "PointDivision": "25"
+    },
+    {
+      "Key": "Stock/600mm HE Shell",
+      "Name": "600mm HE-SH Shell",
+      "PointCost": "1",
+      "PointDivision": "25"
+    },
+    {
+      "Key": "Stock/600mm Bomb Shell",
+      "Name": "600mm Bomb Shell",
+      "PointCost": "1",
+      "PointDivision": "25"
+    },
+    {
+      "Key": "Stock/S1 Rocket",
+      "Name": "R-2 'Piranha' Rocket",
+      "PointCost": "3",
+      "PointDivision": "1"
+    },
+    {
+      "Key": "Stock/S3 Mine",
+      "Name": "M-30 'Mattock' Mine",
+      "PointCost": "6",
+      "PointDivision": "1"
+    },
+    {
+      "Key": "Stock/S3 Net Mine",
+      "Name": "M-30-N 'Mattock' Cooperative Mine",
+      "PointCost": "6",
+      "PointDivision": "1"
+    },
+    {
+      "Key": "Stock/S3 Sprint Mine",
+      "Name": "M-50 'Auger' Sprint Mine",
+      "PointCost": "10",
+      "PointDivision": "1"
+    },
+    {
+      "Key": "Stock/Mine Container",
+      "Name": "CM-4M Mine Container",
+      "PointCost": "15",
+      "PointDivision": "1"
+    },
+    {
+      "Key": "Stock/Rocket Container",
+      "Name": "CM-4R6 Rocket Container",
+      "PointCost": "10",
+      "PointDivision": "1"
+    },
+    {
+      "Key": "Stock/Rocket Container 12",
+      "Name": "CM-4R12 Rocket Container",
+      "PointCost": "35",
+      "PointDivision": "1"
+    },
+    {
+      "Key": "Stock/Decoy Container (Clipper)",
+      "Name": "CM-4D1 Decoy Container (Clipper)",
+      "PointCost": "4",
+      "PointDivision": "1"
+    },
+    {
+      "Key": "Stock/Decoy Container (Line Ship)",
+      "Name": "CM-4D2 Decoy Container (Line Ship)",
+      "PointCost": "6",
+      "PointDivision": "1"
+    }
+  ]
+}

--- a/nfcli/data.py
+++ b/nfcli/data.py
@@ -5,7 +5,8 @@ import logging
 from glob import glob
 
 TAGS_FILE = "data/tags.json"
-
+COMPONENTS_FILE = "data/components.json"
+MUNITIONS_FILE = "data/munitions.json"
 
 def load_json(path: str) -> dict:
     try:
@@ -60,6 +61,42 @@ class _Tags:
         for key in removed_keys:
             self.tags.pop(key)
 
+class _Components:
+    def __init__(self) -> None:
+        self.components = load_json(COMPONENTS_FILE).get("Components")
+
+    def get_name(self, key: str) -> str | None:
+        for component in self.components:
+            if component.get("Key") == key:
+                return component.get("Name")
+        return None
+        
+    def get_name_or_key(self, key: str) -> str:
+        name = self.get_name(key)
+        if name is None:
+            return key
+        else:
+            return name
+
+class _Munitions:
+    def __init__(self) -> None:
+        self.munitions = load_json(MUNITIONS_FILE).get("Munitions")
+
+    def get_name(self, key: str) -> str | None:
+        for munition in self.munitions:
+            if munition.get("Key") == key:
+                return munition.get("Name")
+        return None
+
+    def get_name_or_key(self, key: str) -> str:
+        name = self.get_name(key)
+        if name is None:
+            return key
+        else:
+            return name
+
 
 Hulls = _Hulls()
 Tags = _Tags()
+Components = _Components()
+Munitions = _Munitions()

--- a/nfcli/parsers.py
+++ b/nfcli/parsers.py
@@ -3,7 +3,7 @@ import logging
 import xmltodict
 
 from nfcli import strip_tags
-from nfcli.data import Hulls, Tags
+from nfcli.data import Hulls, Tags, Components, Munitions
 from nfcli.models import Content, Fleet, Missile, Ship, Socket
 from nfcli.printers import Printable
 
@@ -16,7 +16,7 @@ def get_content(content_data: dict) -> list[Content]:
             all_loads += content_data[key]["MagSaveData"]
 
     for load in all_loads:
-        content.append(Content(load["MunitionKey"], load["Quantity"]))
+        content.append(Content(Munitions.get_name_or_key(load["MunitionKey"]), load["Quantity"]))
 
     return content
 
@@ -26,7 +26,7 @@ def get_socket(socket_data: dict) -> Socket:
     content = []
     if "ComponentData" in socket_data:
         content = get_content(socket_data["ComponentData"])
-    return Socket(socket_data["Key"], name, content, Tags.get(name))
+    return Socket(socket_data["Key"], Components.get_name_or_key(name), content, Tags.get(name))
 
 
 def get_ship(ship_data: dict) -> Ship:


### PR DESCRIPTION
- Resized the Monitor's main spinal mount
- Added two small module sockets to the Monitor
- Updated the provided starter fleet files
- Adjusted parser/printer so it shows the actual names of components and munitions, not their key addresses

That last one has been needed for a while but it really has to be done now, because a lot of OSP equipment is being renamed in this update. And when a rename happens, the name is updated but the key address stays the same.