### PR TITLE
Fix NoneType error for fleets with no missile types present

### DIFF
--- a/nfcli/parsers.py
+++ b/nfcli/parsers.py
@@ -114,7 +114,10 @@ def parse_fleet(xml_data: str) -> Fleet:
         ship = get_ship(ship_data)
         fleet.add_ship(ship)
 
-    missile_templates = fleet_data.get("MissileTypes", {}).get("MissileTemplate", [])
+    missile_types = fleet_data.get("MissileTypes", {})
+    if not missile_types:
+        return fleet
+    missile_templates = missile_types.get("MissileTemplate", [])
     if not missile_templates:
         return fleet
 


### PR DESCRIPTION
currently some fleets can have a valid MissileType entry in the fleet_data dict, but that entry is None.

This fixes nonetype errors on those fleets, e.g.
[76561198054330246_12394.53.fleet.txt](https://github.com/user-attachments/files/19876655/76561198054330246_12394.53.fleet.txt)
